### PR TITLE
Feature consumer group events

### DIFF
--- a/kafka-sharp/kafka-sharp/Public/KafkaConsumer.cs
+++ b/kafka-sharp/kafka-sharp/Public/KafkaConsumer.cs
@@ -25,6 +25,16 @@ namespace Kafka.Public
         event Action<KafkaRecord<TKey, TValue>> MessageReceived;
 
         /// <summary>
+        /// Signaled when partitions have been assigned by group coordinator
+        /// </summary>
+        event Action<IDictionary<string, ISet<int>>> PartitionsAssigned;
+
+        /// <summary>
+        /// Signaled when partitions have been revoked
+        /// </summary>
+        event Action PartitionsRevoked;
+
+        /// <summary>
         /// Raised when a fetch request has been throttled server side.
         /// </summary>
         event Action<int> Throttled;
@@ -177,11 +187,17 @@ namespace Kafka.Public
 
             _clusterClient.MessageReceived += OnClusterMessage;
             _clusterClient.ConsumeThrottled += t => Throttled(t);
+            _clusterClient.PartitionsAssigned += PartitionsAssigned;
+            _clusterClient.PartitionsRevoked += PartitionsRevoked;
             _messagesSub = _clusterClient.Messages.Where(CheckRecord).Select(ToRecord).Subscribe(_messages.OnNext);
         }
 
         public event Action<KafkaRecord<TKey, TValue>> MessageReceived = _ => { };
         public event Action<int> Throttled = _ => { };
+
+        public event Action<IDictionary<string, ISet<int>>> PartitionsAssigned = x => { };
+
+        public event Action PartitionsRevoked = () => { };
 
         public IObservable<KafkaRecord<TKey, TValue>> Messages
         {

--- a/kafka-sharp/kafka-sharp/Routing/ConsumerRouter.cs
+++ b/kafka-sharp/kafka-sharp/Routing/ConsumerRouter.cs
@@ -105,7 +105,7 @@ namespace Kafka.Routing
         /// <summary>
         /// Signaled when partitions have been assigned by group coordinator
         /// </summary>
-        event Action<IDictionary<string, ISet<PartitionOffset>>> PartitionsAssigned;
+        event Action<IDictionary<string, ISet<int>>> PartitionsAssigned;
 
         /// <summary>
         /// Signaled when partitions have been revoked
@@ -353,9 +353,9 @@ namespace Kafka.Routing
 
         public event Action<int> Throttled = t => { };
 
-        public event Action<IDictionary<string, ISet<PartitionOffset>>> PartitionsAssigned = x => { };
+        public event Action<IDictionary<string, ISet<int>>> PartitionsAssigned = x => { };
 
-        public event Action PartitionsRevoked = () => {};
+        public event Action PartitionsRevoked = () => { };
 
         /// <summary>
         /// Raised in case of unexpected internal error.
@@ -643,7 +643,8 @@ namespace Kafka.Routing
                     }
                 }
 
-                PartitionsAssigned(joined.Assignments);
+                PartitionsAssigned(
+                    joined.Assignments.ToDictionary(x => x.Key, x => (ISet<int>)new HashSet<int>(x.Value.Select(y => y.Partition))));
 
                 _partitionAssignments = joined.Assignments;
             }

--- a/kafka-sharp/kafka-sharp/Routing/ConsumerRouter.cs
+++ b/kafka-sharp/kafka-sharp/Routing/ConsumerRouter.cs
@@ -101,6 +101,16 @@ namespace Kafka.Routing
         /// Signaled when a fetch response has been throttled
         /// </summary>
         event Action<int> Throttled;
+
+        /// <summary>
+        /// Signaled when partitions have been assigned by group coordinator
+        /// </summary>
+        event Action<IDictionary<string, ISet<PartitionOffset>>> PartitionsAssigned;
+
+        /// <summary>
+        /// Signaled when partitions have been revoked
+        /// </summary>
+        event Action PartitionsRevoked;
     }
 
     // Magic values for Offset APIs. Some from Kafka protocol, some special to us
@@ -343,6 +353,10 @@ namespace Kafka.Routing
 
         public event Action<int> Throttled = t => { };
 
+        public event Action<IDictionary<string, ISet<PartitionOffset>>> PartitionsAssigned = x => { };
+
+        public event Action PartitionsRevoked = () => {};
+
         /// <summary>
         /// Raised in case of unexpected internal error.
         /// </summary>
@@ -401,6 +415,7 @@ namespace Kafka.Routing
             _offsetBatchStrategy.Dispose();
             if (_consumerGroup != null)
             {
+                PartitionsRevoked();
                 await CommitAll();
                 await _consumerGroup.LeaveGroup();
                 _heartbeatTimer.Dispose();
@@ -627,6 +642,8 @@ namespace Kafka.Routing
                         }
                     }
                 }
+
+                PartitionsAssigned(joined.Assignments);
 
                 _partitionAssignments = joined.Assignments;
             }
@@ -934,6 +951,8 @@ namespace Kafka.Routing
                     mustRejoin = true;
                     if (result == ErrorCode.RebalanceInProgress)
                     {
+                        PartitionsRevoked();
+
                         // Save offsets before rejoining
                         await CommitAll();
                     }


### PR DESCRIPTION
Working with manual offsets committing I face the next issues:

- There is no possibility to handle RebalanceRequired event for committing current offset cache
- No way to know list of current assigned partitions

The last one is crucial and required to inform offsets commitment unit of current active partitions, otherwise it can sometimes commit old offset from unassigned partition.
I don't see any other way to prevent this behavior.

In other drivers I saw events like PartitionsAssigned / PartitionsRevoked. They might fix this problem.
