### PR TITLE
Autorecover from OffsetsOutOfRange errors

### DIFF
--- a/kafka-sharp/kafka-sharp/Public/Configuration.cs
+++ b/kafka-sharp/kafka-sharp/Public/Configuration.cs
@@ -311,11 +311,20 @@ namespace Kafka.Public
         /// Serialization configuration options and (de)serializers.
         /// </summary>
         public SerializationConfig SerializationConfig = new SerializationConfig();
+
+        /// <summary>
+        /// What to do in case of offset out range error when reading a partition.
+        /// Switch to earliest offset or latest offset.
+        /// </summary>
+        public Offset OffsetOutOfRangeStrategy = Offset.Earliest;
     }
 
     public enum Offset
     {
         Earliest = -2,
+        Latest = -1,
+
+        [Obsolete]
         Lastest = -1
     }
 

--- a/kafka-sharp/kafka-sharp/Routing/ConsumerGroup.cs
+++ b/kafka-sharp/kafka-sharp/Routing/ConsumerGroup.cs
@@ -321,7 +321,7 @@ namespace Kafka.Routing
                 case Public.Offset.Earliest:
                     return -2;
 
-                case Public.Offset.Lastest:
+                case Public.Offset.Latest:
                     return -1;
 
                 default:


### PR DESCRIPTION
- In case of OffsetsOutOfRange errors, switch to read from earliest or
  latest offset according to configuration (previsouly it required manual
  administration on the cluster to reset out of range consumer groups).

Change-Id: I77164fc201ec16acba1ce3296d2c03d66d9223fd