### PR TITLE
Race condition when complete connection async send

### DIFF
--- a/kafka-sharp/kafka-sharp/Network/Connection.cs
+++ b/kafka-sharp/kafka-sharp/Network/Connection.cs
@@ -365,7 +365,6 @@ namespace Kafka.Network
             _bufferPool.Release(_sendContext.Buffer);
             _sendContext.Buffer = null;
             _sendContext.Data = null;
-            _sendContext.Promise = null;
         }
 
         // Async send loop body
@@ -381,9 +380,9 @@ namespace Kafka.Network
 
             if (saea.SocketError != SocketError.Success)
             {
+                connection.CleanSend();
                 connection._sendContext.Promise.SetException(new TransportException(TransportError.WriteError,
                     new SocketException((int) saea.SocketError)));
-                connection.CleanSend();
                 return;
             }
 
@@ -402,8 +401,8 @@ namespace Kafka.Network
                 }
                 else
                 {
-                    connection._sendContext.Promise.SetResult(SuccessResult);
                     connection.CleanSend();
+                    connection._sendContext.Promise.SetResult(SuccessResult);
                 }
             }
         }


### PR DESCRIPTION
_"An asynchronous socket operation is already in progress using this SocketAsyncEventArgs instance"_ exception thrown on produce stress testing.

There are race condition when connection completes sending after async mode.
Context clean-up must be before promise result set, because context can be overriden by next SendAsync call.