### PR TITLE
More resilient consumer + various fixes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ before_build:
 build_script:
 - dotnet build "kafka-sharp/kafka-sharp-netstd.sln" -c %CONFIGURATION%
 after_build:
-- dotnet pack /p:PackageVersion="%APPVEYOR_REPO_TAG_NAME%" "kafka-sharp/kafka-sharp/Kafka.netstandard.csproj" -c %CONFIGURATION% --no-build -o %APPVEYOR_BUILD_FOLDER%\artifacts
+- cmd: IF "%APPVEYOR_REPO_TAG%" == "true" (dotnet pack /p:PackageVersion="%APPVEYOR_REPO_TAG_NAME%" "kafka-sharp/kafka-sharp/Kafka.netstandard.csproj" -c %CONFIGURATION% --no-build -o %APPVEYOR_BUILD_FOLDER%\artifacts)
 test_script:
 - dotnet test "kafka-sharp/kafka-sharp.UTest/kafka.UTest.netstandard.csproj" -c %CONFIGURATION%
 cache:

--- a/kafka-sharp/kafka-sharp.UTest/Kafka.UTest.csproj
+++ b/kafka-sharp/kafka-sharp.UTest/Kafka.UTest.csproj
@@ -63,6 +63,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.ValueTuple">
+      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/kafka-sharp/kafka-sharp.UTest/Mocks.cs
+++ b/kafka-sharp/kafka-sharp.UTest/Mocks.cs
@@ -367,11 +367,12 @@ namespace tests_kafka_sharp
         private static int _count;
         private readonly int _responseDelayMs;
 
-        private readonly Queue<Timer> _timers = new Queue<Timer>();
+        private static ConcurrentQueue<Timer> _timers = new ConcurrentQueue<Timer>();
 
         public static void Reset()
         {
             _count = 1;
+            _timers = new ConcurrentQueue<Timer>();
         }
 
         public EchoConnectionMock(bool forceErrors = false, int responseDelayMs = 0)
@@ -413,10 +414,6 @@ namespace tests_kafka_sharp
                         OnResponse(correlationId, response);
                         tcs.SetResult(true);
                     }, null, _responseDelayMs, -1);
-                    while (_timers.Count > 100) // We should have only a few request pending at a time. It should be safe to dispose the old timers at this point.
-                    {
-                        _timers.Dequeue();
-                    }
                     _timers.Enqueue(timer);
                     return tcs.Task;
                 }

--- a/kafka-sharp/kafka-sharp.UTest/TestConsumer.cs
+++ b/kafka-sharp/kafka-sharp.UTest/TestConsumer.cs
@@ -144,25 +144,7 @@ namespace tests_kafka_sharp
         [TestCase(Offsets.Earliest)]
         public void TestStart_OnePartition_OffsetUnknown(long offset)
         {
-            var node = new Mock<INode>();
-            var cluster = new Mock<ICluster>();
-            cluster.Setup(c => c.RequireNewRoutingTable())
-                .Returns(() =>
-                    Task.FromResult(
-                        new RoutingTable(new Dictionary<string, Partition[]>
-                        {
-                            {
-                                TOPIC,
-                                new[]
-                                {
-                                    new Partition {Id = 0, Leader = node.Object},
-                                    new Partition {Id = 1, Leader = node.Object},
-                                    new Partition {Id = 2, Leader = node.Object}
-                                }
-                            }
-                        })));
-            var configuration = new Configuration {TaskScheduler = new CurrentThreadTaskScheduler()};
-            var consumer = new ConsumeRouter(cluster.Object, configuration, 1);
+            var (node, _, cluster, consumer) = CreateMocksAndConsumerWithOneTopic3Partitions();
             consumer.StartConsume(TOPIC, PARTITION, offset);
             cluster.Verify(c => c.RequireAllPartitionsForTopic(It.IsAny<string>()), Times.Never());
             cluster.Verify(c => c.RequireNewRoutingTable(), Times.AtLeastOnce());
@@ -213,25 +195,7 @@ namespace tests_kafka_sharp
         [Test]
         public void TestStart_OnePartition_KnownOffset()
         {
-            var node = new Mock<INode>();
-            var cluster = new Mock<ICluster>();
-            cluster.Setup(c => c.RequireNewRoutingTable())
-                .Returns(() =>
-                    Task.FromResult(
-                        new RoutingTable(new Dictionary<string, Partition[]>
-                        {
-                            {
-                                TOPIC,
-                                new[]
-                                {
-                                    new Partition {Id = 0, Leader = node.Object},
-                                    new Partition {Id = 1, Leader = node.Object},
-                                    new Partition {Id = 2, Leader = node.Object}
-                                }
-                            }
-                        })));
-            var configuration = new Configuration {TaskScheduler = new CurrentThreadTaskScheduler()};
-            var consumer = new ConsumeRouter(cluster.Object, configuration, 1);
+            var (node, configuration, cluster, consumer) = CreateMocksAndConsumerWithOneTopic3Partitions();
             consumer.StartConsume(TOPIC, PARTITION, OFFSET);
             cluster.Verify(c => c.RequireAllPartitionsForTopic(It.IsAny<string>()), Times.Never());
             cluster.Verify(c => c.RequireNewRoutingTable(), Times.AtLeastOnce());
@@ -318,25 +282,7 @@ namespace tests_kafka_sharp
         [TestCase(OFFSET + 1)]
         public void TestStopConsumeBeforeFetchLoop(long offset)
         {
-            var node = new Mock<INode>();
-            var cluster = new Mock<ICluster>();
-            cluster.Setup(c => c.RequireNewRoutingTable())
-                .Returns(() =>
-                    Task.FromResult(
-                        new RoutingTable(new Dictionary<string, Partition[]>
-                        {
-                            {
-                                TOPIC,
-                                new[]
-                                {
-                                    new Partition {Id = 0, Leader = node.Object},
-                                    new Partition {Id = 1, Leader = node.Object},
-                                    new Partition {Id = 2, Leader = node.Object}
-                                }
-                            }
-                        })));
-            var configuration = new Configuration { TaskScheduler = new CurrentThreadTaskScheduler() };
-            var consumer = new ConsumeRouter(cluster.Object, configuration, 1);
+            var (node, _, _, consumer) = CreateMocksAndConsumerWithOneTopic3Partitions();
             consumer.StartConsume(TOPIC, PARTITION, Offsets.Latest);
             consumer.StopConsume(TOPIC, PARTITION, offset);
 
@@ -382,25 +328,7 @@ namespace tests_kafka_sharp
         [TestCase(Offsets.Now)]
         public void TestStopConsumeAfterFetchLoop(long offset)
         {
-            var node = new Mock<INode>();
-            var cluster = new Mock<ICluster>();
-            cluster.Setup(c => c.RequireNewRoutingTable())
-                .Returns(() =>
-                    Task.FromResult(
-                        new RoutingTable(new Dictionary<string, Partition[]>
-                        {
-                            {
-                                TOPIC,
-                                new[]
-                                {
-                                    new Partition {Id = 0, Leader = node.Object},
-                                    new Partition {Id = 1, Leader = node.Object},
-                                    new Partition {Id = 2, Leader = node.Object}
-                                }
-                            }
-                        })));
-            var configuration = new Configuration { TaskScheduler = new CurrentThreadTaskScheduler() };
-            var consumer = new ConsumeRouter(cluster.Object, configuration, 1);
+            var (node, _, _, consumer) = CreateMocksAndConsumerWithOneTopic3Partitions();
             consumer.StartConsume(TOPIC, PARTITION, OFFSET);
             consumer.StopConsume(TOPIC, PARTITION, offset);
 
@@ -462,25 +390,7 @@ namespace tests_kafka_sharp
         [Test]
         public void TestStopConsumeAfterFetchLoopMultiple()
         {
-            var node = new Mock<INode>();
-            var cluster = new Mock<ICluster>();
-            cluster.Setup(c => c.RequireNewRoutingTable())
-                .Returns(() =>
-                    Task.FromResult(
-                        new RoutingTable(new Dictionary<string, Partition[]>
-                        {
-                            {
-                                TOPIC,
-                                new[]
-                                {
-                                    new Partition {Id = 0, Leader = node.Object},
-                                    new Partition {Id = 1, Leader = node.Object},
-                                    new Partition {Id = 2, Leader = node.Object}
-                                }
-                            }
-                        })));
-            var configuration = new Configuration { TaskScheduler = new CurrentThreadTaskScheduler() };
-            var consumer = new ConsumeRouter(cluster.Object, configuration, 1);
+            var (node, _, _, consumer) = CreateMocksAndConsumerWithOneTopic3Partitions();
             consumer.StartConsume(TOPIC, 0, OFFSET);
             consumer.StartConsume(TOPIC, 1, OFFSET);
             consumer.StopConsume(TOPIC, Partitions.All, Offsets.Now);
@@ -568,25 +478,7 @@ namespace tests_kafka_sharp
         [Test]
         public void TestStopAndStartConsume_SpecificOffsets()
         {
-            var node = new Mock<INode>();
-            var cluster = new Mock<ICluster>();
-            cluster.Setup(c => c.RequireNewRoutingTable())
-                .Returns(() =>
-                    Task.FromResult(
-                        new RoutingTable(new Dictionary<string, Partition[]>
-                        {
-                            {
-                                TOPIC,
-                                new[]
-                                {
-                                    new Partition {Id = 0, Leader = node.Object},
-                                    new Partition {Id = 1, Leader = node.Object},
-                                    new Partition {Id = 2, Leader = node.Object}
-                                }
-                            }
-                        })));
-            var configuration = new Configuration { TaskScheduler = new CurrentThreadTaskScheduler() };
-            var consumer = new ConsumeRouter(cluster.Object, configuration, 1);
+            var (node, _, _, consumer) = CreateMocksAndConsumerWithOneTopic3Partitions();
 
             var offsets = new List<long>();
             consumer.MessageReceived += r => offsets.Add(r.Offset);
@@ -706,25 +598,7 @@ namespace tests_kafka_sharp
         // i.e. Restart is sent after Stop has been fully completed
         public void TestResume_NoOperationPending()
         {
-            var node = new Mock<INode>();
-            var cluster = new Mock<ICluster>();
-            cluster.Setup(c => c.RequireNewRoutingTable())
-                .Returns(() =>
-                    Task.FromResult(
-                        new RoutingTable(new Dictionary<string, Partition[]>
-                        {
-                            {
-                                TOPIC,
-                                new[]
-                                {
-                                    new Partition {Id = 0, Leader = node.Object},
-                                    new Partition {Id = 1, Leader = node.Object},
-                                    new Partition {Id = 2, Leader = node.Object}
-                                }
-                            }
-                        })));
-            var configuration = new Configuration { TaskScheduler = new CurrentThreadTaskScheduler() };
-            var consumer = new ConsumeRouter(cluster.Object, configuration, 1);
+            var (node, _, _, consumer) = CreateMocksAndConsumerWithOneTopic3Partitions();
 
             var offsets = new List<long>();
             consumer.MessageReceived += r => offsets.Add(r.Offset);
@@ -810,25 +684,7 @@ namespace tests_kafka_sharp
         // i.e. Restart is sent while previous stop operation is not fully completed
         public void TestResume_FetchPending()
         {
-            var node = new Mock<INode>();
-            var cluster = new Mock<ICluster>();
-            cluster.Setup(c => c.RequireNewRoutingTable())
-                .Returns(() =>
-                    Task.FromResult(
-                        new RoutingTable(new Dictionary<string, Partition[]>
-                        {
-                            {
-                                TOPIC,
-                                new[]
-                                {
-                                    new Partition {Id = 0, Leader = node.Object},
-                                    new Partition {Id = 1, Leader = node.Object},
-                                    new Partition {Id = 2, Leader = node.Object}
-                                }
-                            }
-                        })));
-            var configuration = new Configuration { TaskScheduler = new CurrentThreadTaskScheduler() };
-            var consumer = new ConsumeRouter(cluster.Object, configuration, 1);
+            var (node, _, _, consumer) = CreateMocksAndConsumerWithOneTopic3Partitions();
 
             var offsets = new List<long>();
             consumer.MessageReceived += r => offsets.Add(r.Offset);
@@ -918,25 +774,7 @@ namespace tests_kafka_sharp
         // while we were waiting for a list operation to complete
         public void TestResume_OffsetPending()
         {
-            var node = new Mock<INode>();
-            var cluster = new Mock<ICluster>();
-            cluster.Setup(c => c.RequireNewRoutingTable())
-                .Returns(() =>
-                    Task.FromResult(
-                        new RoutingTable(new Dictionary<string, Partition[]>
-                        {
-                            {
-                                TOPIC,
-                                new[]
-                                {
-                                    new Partition {Id = 0, Leader = node.Object},
-                                    new Partition {Id = 1, Leader = node.Object},
-                                    new Partition {Id = 2, Leader = node.Object}
-                                }
-                            }
-                        })));
-            var configuration = new Configuration { TaskScheduler = new CurrentThreadTaskScheduler() };
-            var consumer = new ConsumeRouter(cluster.Object, configuration, 1);
+            var (node, _, _, consumer) = CreateMocksAndConsumerWithOneTopic3Partitions();
 
             consumer.StartConsume(TOPIC, PARTITION, Offsets.Latest);
 
@@ -1375,5 +1213,33 @@ namespace tests_kafka_sharp
             
             Assert.AreEqual(42, throttled);
         }
+
+        #region helpers
+
+        // Setup Node and cluster mocks with 1 topic 3 partitions, then create a consumer and returns them all.
+        private (Mock<INode>, Configuration, Mock<ICluster>, ConsumeRouter) CreateMocksAndConsumerWithOneTopic3Partitions()
+        {
+            var node = new Mock<INode>();
+            var cluster = new Mock<ICluster>();
+            cluster.Setup(c => c.RequireNewRoutingTable())
+                .Returns(() =>
+                    Task.FromResult(
+                        new RoutingTable(new Dictionary<string, Partition[]>
+                        {
+                            {
+                                TOPIC,
+                                new[]
+                                {
+                                    new Partition {Id = 0, Leader = node.Object},
+                                    new Partition {Id = 1, Leader = node.Object},
+                                    new Partition {Id = 2, Leader = node.Object}
+                                }
+                            }
+                        })));
+            var configuration = new Configuration { TaskScheduler = new CurrentThreadTaskScheduler() };
+            var consumer = new ConsumeRouter(cluster.Object, configuration, 1);
+            return (node, configuration, cluster, consumer);
+        }
+        #endregion  
     }
 }

--- a/kafka-sharp/kafka-sharp.UTest/TestConsumerGroup.cs
+++ b/kafka-sharp/kafka-sharp.UTest/TestConsumerGroup.cs
@@ -779,7 +779,7 @@ namespace tests_kafka_sharp
 
             consumer.StartConsumeSubscription(mocks.Group.Object, new[] { "the topic" });
 
-            WaitOneSecondMaxForEvent("heatbeat", mocks.HeartbeatCalled);
+            await HeartbeatFinishedProcessing(mocks, consumer);
 
             mocks.Group.Verify(g => g.Join(It.IsAny<IEnumerable<string>>()), Times.AtLeast(2));
             // No Commit tried in case of ""hard" heartbeat errors

--- a/kafka-sharp/kafka-sharp.UTest/kafka.UTest.netstandard.csproj
+++ b/kafka-sharp/kafka-sharp.UTest/kafka.UTest.netstandard.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="System.Reactive.Interfaces" Version="3.1.1" />
     <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/kafka-sharp/kafka-sharp/Protocol/Errors.cs
+++ b/kafka-sharp/kafka-sharp/Protocol/Errors.cs
@@ -230,5 +230,10 @@ namespace Kafka.Protocol
 
         // Local error, not from brokers
         LocalError = -42,
+
+        /// <summary>
+        /// Deserialization on one message failed (bad Crc, magic number or compression)
+        /// </summary>
+        DeserializationError = -43,
     }
 }

--- a/kafka-sharp/kafka-sharp/Protocol/FetchResponse.cs
+++ b/kafka-sharp/kafka-sharp/Protocol/FetchResponse.cs
@@ -81,7 +81,15 @@ namespace Kafka.Protocol
             Partition = BigEndianConverter.ReadInt32(stream);
             ErrorCode = (ErrorCode) BigEndianConverter.ReadInt16(stream);
             HighWatermarkOffset = BigEndianConverter.ReadInt64(stream);
-            Messages = DeserializeMessageSet(stream, extra as Deserializers);
+            try
+            {
+                Messages = DeserializeMessageSet(stream, extra as Deserializers);
+            }
+            catch (ProtocolException pEx)
+            {
+                pEx.Partition = Partition;
+                throw;
+            }
         }
 
         internal static List<ResponseMessage> DeserializeMessageSet(ReusableMemoryStream stream, Deserializers deserializers)

--- a/kafka-sharp/kafka-sharp/Protocol/ProtocolException.cs
+++ b/kafka-sharp/kafka-sharp/Protocol/ProtocolException.cs
@@ -5,6 +5,10 @@ namespace Kafka.Protocol
 {
     class ProtocolException : Exception
     {
+        // Fields to identify the faulty message (useful in case the exception stops a batch)
+        internal string Topic;
+        internal int Partition;
+
         public ProtocolException(string message) : base(message)
         {
         }

--- a/kafka-sharp/kafka-sharp/Protocol/TopicData.cs
+++ b/kafka-sharp/kafka-sharp/Protocol/TopicData.cs
@@ -37,12 +37,20 @@ namespace Kafka.Protocol
                 var config = extra as SerializationConfig;
                 pdExtra = config.GetDeserializersForTopic(TopicName);
             }
-            for (int i = 0; i < count; ++i)
+            try
             {
-                array[i] = new TPartitionData();
-                array[i].Deserialize(stream, pdExtra, version);
+                for (int i = 0; i < count; ++i)
+                {
+                    array[i] = new TPartitionData();
+                    array[i].Deserialize(stream, pdExtra, version);
+                }
+                PartitionsData = array;
             }
-            PartitionsData = array;
+            catch (ProtocolException pEx)
+            {
+                pEx.Topic = TopicName;
+                throw;
+            }
         }
 
         #endregion

--- a/kafka-sharp/kafka-sharp/Public/Configuration.cs
+++ b/kafka-sharp/kafka-sharp/Public/Configuration.cs
@@ -55,7 +55,7 @@ namespace Kafka.Public
     }
 
     /// <summary>
-    /// In case of network errors
+    /// In case of network or protocol errors
     /// </summary>
     public enum ErrorStrategy
     {
@@ -65,7 +65,8 @@ namespace Kafka.Public
         Discard,
 
         /// <summary>
-        /// Retry sending messsages (this may end up in duplicate messages)
+        /// Retry sending messsages (this may end up in duplicate messages) for Producer.
+        /// Retry fetching messages (this may end up in an infinite loop) for Consumer.
         /// </summary>
         Retry
     }
@@ -142,9 +143,14 @@ namespace Kafka.Public
         public TimeSpan TemporaryIgnorePartitionTime = TimeSpan.FromSeconds(42);
 
         /// <summary>
-        /// Strategy in case opf network errors.
+        /// Strategy in case opf network errors for Producer.
         /// </summary>
         public ErrorStrategy ErrorStrategy = ErrorStrategy.Discard;
+
+        /// <summary>
+        /// Strategy in case of deserialization Error for Consumer.
+        /// </summary>
+        public ErrorStrategy ConsumerErrorStrategy = ErrorStrategy.Discard;
 
         /// <summary>
         /// Time slice for batching messages. We wait  that much time at most before processing

--- a/kafka-sharp/kafka-sharp/Routing/ConsumerRouter.cs
+++ b/kafka-sharp/kafka-sharp/Routing/ConsumerRouter.cs
@@ -1113,6 +1113,15 @@ namespace Kafka.Routing
                 state.Active = false;
                 StartConsume(topic, partitionResponse.Partition, (long)_configuration.OffsetOutOfRangeStrategy);
             }
+            else if (partitionResponse.ErrorCode == ErrorCode.DeserializationError
+                && _configuration.ConsumerErrorStrategy == ErrorStrategy.Discard)
+            {
+                _cluster.Logger.LogError(
+                    $"Could not deserialize a message for topic {topic} / partition {partitionResponse.Partition}."
+                    + " Because our configuration is set to 'ConsumerErrorStrategy == Discard', we will now read from latest offset.");
+                state.Active = false;
+                StartConsume(topic, partitionResponse.Partition, (long)Public.Offset.Latest);
+            }
             else
             {
                 if (CheckActivity(state, topic, partitionResponse.Partition))


### PR DESCRIPTION
The consumer will no longer block on a corrupted message. The messages of the partition will be skipped (but previous "retry" behavior  can still be configured).
Fixed potential race-condition when releasing message buffers.
Fixed some flaky tests.
