### PR TITLE
Version 0.11

### DIFF
--- a/kafka-sharp/kafka-sharp.UTest/Kafka.UTest.csproj
+++ b/kafka-sharp/kafka-sharp.UTest/Kafka.UTest.csproj
@@ -69,6 +69,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="TestVarIntConverter.cs" />
     <Compile Include="TestBatching.cs" />
     <Compile Include="TestClient.cs" />
     <Compile Include="TestConsumerGroup.cs" />

--- a/kafka-sharp/kafka-sharp.UTest/TestClient.cs
+++ b/kafka-sharp/kafka-sharp.UTest/TestClient.cs
@@ -323,10 +323,11 @@ namespace tests_kafka_sharp
                 producer.Produce("key", "data");
                 producer.Produce("key", "data", 42);
 
-                client.Verify(c => c.Produce(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<object>(), It.IsAny<int>()), Times.Exactly(3));
-                client.Verify(c => c.Produce("topic", null, "data", Partitions.Any), Times.Once());
-                client.Verify(c => c.Produce("topic", "key", "data", Partitions.Any), Times.Once());
-                client.Verify(c => c.Produce("topic", "key", "data", 42), Times.Once());
+                client.Verify(c => c.Produce(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<object>(),
+                    It.IsAny<ICollection<KafkaRecordHeader>>(), It.IsAny<int>(), It.IsAny<DateTime>()), Times.Exactly(3));
+                client.Verify(c => c.Produce("topic", null, "data", null, Partitions.Any, It.IsAny<DateTime>()), Times.Once());
+                client.Verify(c => c.Produce("topic", "key", "data", null, Partitions.Any, It.IsAny<DateTime>()), Times.Once());
+                client.Verify(c => c.Produce("topic", "key", "data", null, 42, It.IsAny<DateTime>()), Times.Once());
 
                 // Discarded/Expired messages are correctly transmitted
                 bool discardedThroughEvent = false;

--- a/kafka-sharp/kafka-sharp.UTest/TestNode.cs.cs
+++ b/kafka-sharp/kafka-sharp.UTest/TestNode.cs.cs
@@ -59,7 +59,7 @@ namespace tests_kafka_sharp
 
             var node = new Node("Node", () => connection.Object,
                 new Node.Serialization(new SerializationConfig(), Compatibility.V0_8_2, Pool, new byte[0],
-                    RequiredAcks.Leader, 1, CompressionCodec.None, 0, 100),
+                    RequiredAcks.Leader, 1, CompressionCodec.None, 0, 100, 100),
                 new Configuration
                 {
                     ConsumeBufferingTime = TimeSpan.FromMilliseconds(15),
@@ -78,7 +78,7 @@ namespace tests_kafka_sharp
 
             node = new Node("Node", () => connection.Object,
                 new Node.Serialization(new SerializationConfig(), Compatibility.V0_10_1, Pool, new byte[0],
-                    RequiredAcks.Leader, 1, CompressionCodec.None, 0, 100),
+                    RequiredAcks.Leader, 1, CompressionCodec.None, 0, 100, 100),
                 new Configuration
                 {
                     ConsumeBufferingTime = TimeSpan.FromMilliseconds(15),
@@ -331,7 +331,7 @@ namespace tests_kafka_sharp
 
             var node = new Node("Node", () => connection.Object,
                 new Node.Serialization(new SerializationConfig(), Compatibility.V0_8_2, Pool, new byte[0],
-                    RequiredAcks.Leader, 1, CompressionCodec.None, 0, 100),
+                    RequiredAcks.Leader, 1, CompressionCodec.None, 0, 100, 100),
                 new Configuration
                 {
                     ConsumeBufferingTime = TimeSpan.FromMilliseconds(15),
@@ -350,7 +350,7 @@ namespace tests_kafka_sharp
 
             node = new Node("Node", () => connection.Object,
                 new Node.Serialization(new SerializationConfig(), Compatibility.V0_10_1, Pool, new byte[0],
-                    RequiredAcks.Leader, 1, CompressionCodec.None, 0, 100),
+                    RequiredAcks.Leader, 1, CompressionCodec.None, 0, 100, 100),
                 new Configuration
                 {
                     ConsumeBufferingTime = TimeSpan.FromMilliseconds(15),
@@ -684,7 +684,7 @@ namespace tests_kafka_sharp
         public void TestMetadataDecodeError()
         {
             var node = new Node("Pepitomustogussimo", () => new EchoConnectionMock(),
-                                new Node.Serialization(null, Compatibility.V0_8_2, Pool, new byte[0], RequiredAcks.Leader, 1, CompressionCodec.None, 0, 100),
+                                new Node.Serialization(null, Compatibility.V0_8_2, Pool, new byte[0], RequiredAcks.Leader, 1, CompressionCodec.None, 0, 100, 100),
                                 new Configuration());
             Exception ex = null;
             node.DecodeError += (n, e) =>
@@ -740,7 +740,7 @@ namespace tests_kafka_sharp
 
             var node = new Node("Node", () => connection.Object,
                 new Node.Serialization(new SerializationConfig(), Compatibility.V0_8_2, Pool, new byte[0],
-                    RequiredAcks.Leader, 1, CompressionCodec.None, 0, 100),
+                    RequiredAcks.Leader, 1, CompressionCodec.None, 0, 100, 100),
                 new Configuration { ProduceBufferingTime = TimeSpan.FromMilliseconds(15), ProduceBatchSize = 1, TaskScheduler = new CurrentThreadTaskScheduler()}, 1);
 
             node.Produce(ProduceMessage.New("test", 0, new Message(), DateTime.UtcNow.AddDays(1)));
@@ -754,7 +754,7 @@ namespace tests_kafka_sharp
 
             node = new Node("Node", () => connection.Object,
                 new Node.Serialization(new SerializationConfig(), Compatibility.V0_10_1, Pool, new byte[0],
-                    RequiredAcks.Leader, 1, CompressionCodec.None, 0, 100),
+                    RequiredAcks.Leader, 1, CompressionCodec.None, 0, 100, 100),
                 new Configuration { ProduceBufferingTime = TimeSpan.FromMilliseconds(15), ProduceBatchSize = 1, TaskScheduler = new CurrentThreadTaskScheduler() }, 1);
 
             node.Produce(ProduceMessage.New("test", 0, new Message(), DateTime.UtcNow.AddDays(1)));
@@ -832,7 +832,7 @@ namespace tests_kafka_sharp
         public void TestProduceDecodeErrorAreAcknowledged()
         {
             var node = new Node("Pepitomustogussimo", () => new EchoConnectionMock(),
-                                new Node.Serialization(null, Compatibility.V0_8_2, Pool, new byte[0], RequiredAcks.Leader, 1, CompressionCodec.None, 0, 100),
+                                new Node.Serialization(null, Compatibility.V0_8_2, Pool, new byte[0], RequiredAcks.Leader, 1, CompressionCodec.None, 0, 100, 100),
                                 new Configuration
                                     {
                                         ErrorStrategy = ErrorStrategy.Discard,
@@ -870,7 +870,7 @@ namespace tests_kafka_sharp
             // Prepare
             var connection = new Mock<IConnection>();
             var node = new Node("Node", () => connection.Object,
-                new Node.Serialization(null, Compatibility.V0_8_2, Pool, new byte[0], RequiredAcks.Leader, 1, CompressionCodec.None, 0, 100),
+                new Node.Serialization(null, Compatibility.V0_8_2, Pool, new byte[0], RequiredAcks.Leader, 1, CompressionCodec.None, 0, 100, 100),
                 new Configuration
                 {
                     TaskScheduler = new CurrentThreadTaskScheduler(),
@@ -1006,7 +1006,7 @@ namespace tests_kafka_sharp
             // Prepare
             var connection = new Mock<IConnection>();
             var node = new Node("Node", () => connection.Object,
-                new Node.Serialization(null, Compatibility.V0_8_2, Pool, new byte[0], RequiredAcks.Leader, 1, CompressionCodec.None, 0, 100),
+                new Node.Serialization(null, Compatibility.V0_8_2, Pool, new byte[0], RequiredAcks.Leader, 1, CompressionCodec.None, 0, 100, 100),
                 new Configuration
                 {
                     TaskScheduler = new CurrentThreadTaskScheduler(),

--- a/kafka-sharp/kafka-sharp.UTest/TestSerialization.cs
+++ b/kafka-sharp/kafka-sharp.UTest/TestSerialization.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using Kafka.Common;
@@ -22,7 +23,7 @@ namespace tests_kafka_sharp
         private static readonly byte[] ClientId = Encoding.UTF8.GetBytes(TheClientId);
 
         private static readonly Pool<ReusableMemoryStream> Pool =
-            new Pool<ReusableMemoryStream>(() => new ReusableMemoryStream(Pool), (m, b) => { m.SetLength(0); });
+                new Pool<ReusableMemoryStream>(() => new ReusableMemoryStream(Pool), (m, b) => { m.SetLength(0); });
 
         private static int GetExpectedMessageSize(int keyLength, int valueLength, MessageVersion messageVersion)
         {
@@ -99,6 +100,19 @@ namespace tests_kafka_sharp
             public void Serialize(MemoryStream toStream)
             {
                 toStream.Write(Data, 0, Data.Length);
+            }
+        }
+
+        class SimpleSizedSerializable : SimpleSerializable, ISizedMemorySerializable
+        {
+            public SimpleSizedSerializable(byte[] data)
+                : base(data)
+            {
+            }
+
+            public long SerializedSize()
+            {
+                return Data.Length;
             }
         }
 
@@ -538,6 +552,39 @@ namespace tests_kafka_sharp
             }
         }
 
+        private void AssertAreEqual(FetchPartitionData expected, FetchPartitionData result)
+        {
+            Assert.AreEqual(expected.FetchOffset, result.FetchOffset);
+            Assert.AreEqual(expected.MaxBytes, result.MaxBytes);
+            Assert.AreEqual(expected.Partition, result.Partition);
+        }
+
+        private void AssertAreEqual(TopicData<FetchPartitionData> expected, TopicData<FetchPartitionData> result)
+        {
+            Assert.AreEqual(expected.TopicName, result.TopicName);
+            Assert.AreEqual(expected.PartitionsData.Count(), result.PartitionsData.Count());
+            for (int i = 0; i < expected.PartitionsData.Count(); i++)
+            {
+                AssertAreEqual(expected.PartitionsData.ElementAt(i), result.PartitionsData.ElementAt(i));
+            }
+        }
+
+        private readonly TopicData<FetchPartitionData> _topicDataOfFetch1 = new TopicData<FetchPartitionData>
+        {
+            TopicName = "topic1",
+            PartitionsData = new[] { new FetchPartitionData { FetchOffset = 1, MaxBytes = 333, Partition = 42 } }
+        };
+
+        private readonly TopicData<FetchPartitionData> _topicDataOfFetch2 = new TopicData<FetchPartitionData>
+        {
+            TopicName = "topic2",
+            PartitionsData = new[]
+            {
+                new FetchPartitionData { FetchOffset = 1, MaxBytes = 333, Partition = 43 },
+                new FetchPartitionData { FetchOffset = 2, MaxBytes = 89, Partition = 44 }
+            }
+        };
+
         [Test]
         [TestCase(Basics.ApiVersion.V0)]
         [TestCase(Basics.ApiVersion.V2)]
@@ -547,26 +594,7 @@ namespace tests_kafka_sharp
             {
                 MaxWaitTime = 11111,
                 MinBytes = 222222,
-                TopicsData =
-                    new[]
-                    {
-                        new TopicData<FetchPartitionData>
-                        {
-                            TopicName = "topic1",
-                            PartitionsData =
-                                new[] { new FetchPartitionData { FetchOffset = 1, MaxBytes = 333, Partition = 42 } }
-                        },
-                        new TopicData<FetchPartitionData>
-                        {
-                            TopicName = "topic2",
-                            PartitionsData =
-                                new[]
-                                {
-                                    new FetchPartitionData { FetchOffset = 1, MaxBytes = 333, Partition = 43 },
-                                    new FetchPartitionData { FetchOffset = 2, MaxBytes = 89, Partition = 44 }
-                                }
-                        }
-                    }
+                TopicsData = new[] { _topicDataOfFetch1, _topicDataOfFetch2 }
             };
             using (var serialized = fetch.Serialize(new ReusableMemoryStream(null), 1234, ClientId, null, version))
             {
@@ -575,29 +603,125 @@ namespace tests_kafka_sharp
                 Assert.AreEqual(fetch.MaxWaitTime, BigEndianConverter.ReadInt32(serialized));
                 Assert.AreEqual(fetch.MinBytes, BigEndianConverter.ReadInt32(serialized));
                 Assert.AreEqual(2, BigEndianConverter.ReadInt32(serialized)); // 2 elements
-                var td = new TopicData<FetchPartitionData>();
-                td.Deserialize(serialized, null, Basics.ApiVersion.Ignored);
-                Assert.AreEqual("topic1", td.TopicName);
-                Assert.AreEqual(1, td.PartitionsData.Count());
-                var f = td.PartitionsData.First();
-                Assert.AreEqual(1, f.FetchOffset);
-                Assert.AreEqual(333, f.MaxBytes);
-                Assert.AreEqual(42, f.Partition);
 
-                td.Deserialize(serialized, null, Basics.ApiVersion.Ignored);
-                Assert.AreEqual("topic2", td.TopicName);
-                Assert.AreEqual(2, td.PartitionsData.Count());
-                f = td.PartitionsData.First();
-                Assert.AreEqual(1, f.FetchOffset);
-                Assert.AreEqual(333, f.MaxBytes);
-                Assert.AreEqual(43, f.Partition);
+                var topicDataResult = new TopicData<FetchPartitionData>();
+                topicDataResult.Deserialize(serialized, null, Basics.ApiVersion.Ignored);
+                AssertAreEqual(_topicDataOfFetch1, topicDataResult);
 
-                f = td.PartitionsData.ElementAt(1);
-                Assert.AreEqual(2, f.FetchOffset);
-                Assert.AreEqual(89, f.MaxBytes);
-                Assert.AreEqual(44, f.Partition);
+                topicDataResult.Deserialize(serialized, null, Basics.ApiVersion.Ignored);
+                AssertAreEqual(_topicDataOfFetch2, topicDataResult);
             }
         }
+
+        [Test]
+        public void TestSerializeFetchRequestV3()
+        {
+            var fetch = new FetchRequest
+            {
+                MaxWaitTime = 11111,
+                MinBytes = 222222,
+                MaxBytes = 333333,
+                TopicsData = new[] { _topicDataOfFetch1, _topicDataOfFetch2 }
+            };
+            using (var serialized = fetch.Serialize(new ReusableMemoryStream(null), 1234, ClientId, null, Basics.ApiVersion.V3))
+            {
+                CheckHeader(Basics.ApiKey.FetchRequest, (short)Basics.ApiVersion.V3, 1234, TheClientId, serialized);
+                Assert.AreEqual(-1, BigEndianConverter.ReadInt32(serialized)); // ReplicaId
+                Assert.AreEqual(fetch.MaxWaitTime, BigEndianConverter.ReadInt32(serialized));
+                Assert.AreEqual(fetch.MinBytes, BigEndianConverter.ReadInt32(serialized));
+                Assert.AreEqual(fetch.MaxBytes, BigEndianConverter.ReadInt32(serialized));
+                Assert.AreEqual(2, BigEndianConverter.ReadInt32(serialized)); // 2 elements
+
+                var topicDataResult = new TopicData<FetchPartitionData>();
+                topicDataResult.Deserialize(serialized, null, Basics.ApiVersion.V3);
+                AssertAreEqual(_topicDataOfFetch1, topicDataResult);
+
+                topicDataResult.Deserialize(serialized, null, Basics.ApiVersion.V3);
+                AssertAreEqual(_topicDataOfFetch2, topicDataResult);
+            }
+        }
+
+        [Test]
+        public void TestSerializeFetchRequestV4()
+        {
+            var fetch = new FetchRequest
+            {
+                MaxWaitTime = 11111,
+                MinBytes = 222222,
+                MaxBytes = 333333,
+                IsolationLevel = Basics.IsolationLevel.ReadUncommited,
+                TopicsData = new[] { _topicDataOfFetch1, _topicDataOfFetch2 }
+            };
+            using (var serialized = fetch.Serialize(new ReusableMemoryStream(null), 1234, ClientId, null, Basics.ApiVersion.V4))
+            {
+                CheckHeader(Basics.ApiKey.FetchRequest, (short)Basics.ApiVersion.V4, 1234, TheClientId, serialized);
+                Assert.AreEqual(-1, BigEndianConverter.ReadInt32(serialized)); // ReplicaId
+                Assert.AreEqual(fetch.MaxWaitTime, BigEndianConverter.ReadInt32(serialized));
+                Assert.AreEqual(fetch.MinBytes, BigEndianConverter.ReadInt32(serialized));
+                Assert.AreEqual(fetch.MaxBytes, BigEndianConverter.ReadInt32(serialized));
+                Assert.AreEqual(0, serialized.ReadByte()); // IsolationLevel
+                Assert.AreEqual(2, BigEndianConverter.ReadInt32(serialized)); // 2 elements
+
+                var topicDataResult = new TopicData<FetchPartitionData>();
+                topicDataResult.Deserialize(serialized, null, Basics.ApiVersion.V4);
+                AssertAreEqual(_topicDataOfFetch1, topicDataResult);
+
+                topicDataResult.Deserialize(serialized, null, Basics.ApiVersion.V4);
+                AssertAreEqual(_topicDataOfFetch2, topicDataResult);
+            }
+        }
+
+        [Test]
+        public void TestSerializeFetchRequestV5()
+        {
+            var fetch = new FetchRequest
+            {
+                MaxWaitTime = 11111,
+                MinBytes = 222222,
+                MaxBytes = 333333,
+                IsolationLevel = Basics.IsolationLevel.ReadUncommited,
+                TopicsData = new[] { _topicDataOfFetch1, _topicDataOfFetch2 }
+            };
+            using (var serialized = fetch.Serialize(new ReusableMemoryStream(null), 1234, ClientId, null, Basics.ApiVersion.V5))
+            {
+                CheckHeader(Basics.ApiKey.FetchRequest, (short)Basics.ApiVersion.V5, 1234, TheClientId, serialized);
+                Assert.AreEqual(-1, BigEndianConverter.ReadInt32(serialized)); // ReplicaId
+                Assert.AreEqual(fetch.MaxWaitTime, BigEndianConverter.ReadInt32(serialized));
+                Assert.AreEqual(fetch.MinBytes, BigEndianConverter.ReadInt32(serialized));
+                Assert.AreEqual(fetch.MaxBytes, BigEndianConverter.ReadInt32(serialized));
+                Assert.AreEqual(0, serialized.ReadByte()); // IsolationLevel
+                Assert.AreEqual(2, BigEndianConverter.ReadInt32(serialized)); // 2 elements
+
+                var topicDataResult = new TopicData<FetchPartitionData>();
+                topicDataResult.Deserialize(serialized, null, Basics.ApiVersion.V5);
+                AssertAreEqual(_topicDataOfFetch1, topicDataResult);
+                Assert.That(topicDataResult.PartitionsData.All(pd => pd.LogStartOffset == 0));
+
+                topicDataResult.Deserialize(serialized, null, Basics.ApiVersion.V5);
+                AssertAreEqual(_topicDataOfFetch2, topicDataResult);
+                Assert.That(topicDataResult.PartitionsData.All(pd => pd.LogStartOffset == 0));
+            }
+        }
+
+        private static TopicData<PartitionData> CreateTopicDataPartitionData(CompressionCodec codec)
+        {
+            return new TopicData<PartitionData>
+            {
+                TopicName = "barbu",
+                PartitionsData = new[]
+                {
+                    new PartitionData
+                    {
+                        Partition = 22,
+                        CompressionCodec = codec,
+                        Messages = new[] { new Message { Value = TheValue }, new Message { Value = TheValue } },
+                    }
+                }
+            };
+        }
+
+        private readonly TopicData<PartitionData> _defaultTopicDataPartitionData = CreateTopicDataPartitionData(CompressionCodec.None);
+
 
         [Test]
         public void TestSerializeProduceRequest_V0()
@@ -606,25 +730,7 @@ namespace tests_kafka_sharp
             {
                 Timeout = 1223,
                 RequiredAcks = 1,
-                TopicsData =
-                    new[]
-                    {
-                        new TopicData<PartitionData>
-                        {
-                            TopicName = "barbu",
-                            PartitionsData =
-                                new[]
-                                {
-                                    new PartitionData
-                                    {
-                                        Partition = 22,
-                                        CompressionCodec = CompressionCodec.None,
-                                        Messages =
-                                            new[] { new Message { Value = TheValue }, new Message { Value = TheValue } },
-                                    }
-                                }
-                        },
-                    }
+                TopicsData = new[] { _defaultTopicDataPartitionData }
             };
             var config = new SerializationConfig();
             config.SetSerializersForTopic("barbu", new StringSerializer(), new StringSerializer());
@@ -655,24 +761,7 @@ namespace tests_kafka_sharp
             {
                 Timeout = 1223,
                 RequiredAcks = 1,
-                TopicsData =
-                    new[]
-                    {
-                        new TopicData<PartitionData>
-                        {
-                            TopicName = "barbu",
-                            PartitionsData =
-                                new[]
-                                {
-                                    new PartitionData
-                                    {
-                                        Partition = 22,
-                                        CompressionCodec = CompressionCodec.None,
-                                        Messages = new[] { new Message { Value = TheValue }, new Message { Value = TheValue }  },
-                                    }
-                                }
-                        },
-                    }
+                TopicsData = new[] { _defaultTopicDataPartitionData }
             };
             var config = new SerializationConfig();
             config.SetSerializersForTopic("barbu", new StringSerializer(), new StringSerializer());
@@ -694,6 +783,129 @@ namespace tests_kafka_sharp
                 Assert.AreEqual(TheValue, msgs[1].Message.Value as string);
                 Assert.AreEqual(1, msgs[1].Offset);
             }
+        }
+
+        [TestCase("Transactional Id foo", CompressionCodec.None)]
+        [TestCase(null, CompressionCodec.None)]
+        [TestCase(null, CompressionCodec.Gzip)]
+        [Test]
+        public void TestSerializeProduceRequest_V3(string transactionalId, CompressionCodec codec)
+        {
+            var produce = new ProduceRequest
+            {
+                Timeout = 1223,
+                RequiredAcks = 1,
+                TransactionalID = transactionalId,
+                TopicsData = new[] { CreateTopicDataPartitionData(codec) }
+            };
+
+            var config = new SerializationConfig();
+            config.SetSerializersForTopic("barbu", new StringSerializer(), new StringSerializer());
+            config.SetDeserializersForTopic("barbu", new StringDeserializer(), new StringDeserializer());
+
+            using (var serialized = produce.Serialize(Pool.Reserve(), 321, ClientId, config, Basics.ApiVersion.V3))
+            {
+                CheckHeader(Basics.ApiKey.ProduceRequest, 3, 321, TheClientId, serialized);
+                Assert.AreEqual(transactionalId, Basics.DeserializeString(serialized));
+                Assert.AreEqual(produce.RequiredAcks, BigEndianConverter.ReadInt16(serialized));
+                Assert.AreEqual(produce.Timeout, BigEndianConverter.ReadInt32(serialized));
+                Assert.AreEqual(1, BigEndianConverter.ReadInt32(serialized)); // 1 topic data
+                Assert.AreEqual("barbu", Basics.DeserializeString(serialized));
+                Assert.AreEqual(1, BigEndianConverter.ReadInt32(serialized)); // 1 partition data
+
+                Assert.AreEqual(22, BigEndianConverter.ReadInt32(serialized)); // partition id
+                var batchRecordSize = BigEndianConverter.ReadInt32(serialized); // number of bytes to read after this
+                Assert.AreEqual(serialized.Length - serialized.Position, batchRecordSize);
+                Assert.AreEqual(0, BigEndianConverter.ReadInt64(serialized)); // base offset
+                var batchLength = BigEndianConverter.ReadInt32(serialized);
+                var startOfBatchForLength = serialized.Position;
+                Assert.AreEqual(-1, BigEndianConverter.ReadInt32(serialized)); // partitionLeader Epoch
+                Assert.AreEqual(2, serialized.ReadByte()); // magic byte
+                var crcParsed = BigEndianConverter.ReadInt32(serialized);
+                var crcComputed = (int)Crc32.ComputeCastagnoli(serialized, serialized.Position,
+                    serialized.Length - serialized.Position);
+                Assert.AreEqual(crcParsed, crcComputed);
+                Assert.AreEqual((short)codec, BigEndianConverter.ReadInt16(serialized)); // attributes
+                Assert.AreEqual(1, BigEndianConverter.ReadInt32(serialized)); // lastoffsetdelta (2 messages)
+                var firstTimeStamp = BigEndianConverter.ReadInt64(serialized);
+                var maxTimeStamp = BigEndianConverter.ReadInt64(serialized);
+                Assert.AreEqual(firstTimeStamp, maxTimeStamp); // the 2 messages have same timestamp
+                Assert.AreEqual(-1L, BigEndianConverter.ReadInt64(serialized)); // producerId
+                Assert.AreEqual(-1, BigEndianConverter.ReadInt16(serialized)); // producerEpoch
+                Assert.AreEqual(-1, BigEndianConverter.ReadInt32(serialized)); // producerEpoch
+                Assert.AreEqual(2, BigEndianConverter.ReadInt32(serialized)); // number of records
+
+                var deserializer = new StringDeserializer();
+
+                var records = Decompress(serialized, codec);
+
+                // First record
+                var firstRecordLength = VarIntConverter.ReadInt64(records);
+                var startOfFirstRecord = records.Position;
+                Assert.AreEqual(0, records.ReadByte()); // attributes
+                Assert.AreEqual(0, VarIntConverter.ReadInt64(records)); // TimeStampDelta
+                Assert.AreEqual(0, VarIntConverter.ReadInt64(records)); // offsetDelta
+                Assert.AreEqual(-1, VarIntConverter.ReadInt64(records)); // keyLength
+                // Since the keyLength is -1, we do not read the key
+                Assert.AreEqual(Value.Length, VarIntConverter.ReadInt64(records)); //value length
+                Assert.AreEqual(TheValue, deserializer.Deserialize(records, Value.Length));
+                Assert.AreEqual(0, VarIntConverter.ReadInt64(records)); // Headers count
+                // Since the header count is 0, we do not read headers
+                var endOfFirstRecord = records.Position;
+                Assert.AreEqual(firstRecordLength, endOfFirstRecord - startOfFirstRecord);
+
+                // Second record
+                var secondRecordLength = VarIntConverter.ReadInt64(records);
+                var startOfSecondRecord = records.Position;
+                Assert.AreEqual(0, records.ReadByte()); // attributes
+                Assert.AreEqual(0, VarIntConverter.ReadInt64(records)); // TimeStampDelta
+                Assert.AreEqual(1, VarIntConverter.ReadInt64(records)); // offsetDelta
+                Assert.AreEqual(-1, VarIntConverter.ReadInt64(records)); // keyLength
+                // Since the keyLength is -1, we do not read the key
+                Assert.AreEqual(Value.Length, VarIntConverter.ReadInt64(records)); //value length
+                Assert.AreEqual(TheValue, deserializer.Deserialize(records, Value.Length));
+                Assert.AreEqual(0, VarIntConverter.ReadInt64(records)); // Headers count
+                // Since the header count is 0, we do not read headers
+                var endOfSecondRecord = records.Position;
+                Assert.AreEqual(secondRecordLength, endOfSecondRecord - startOfSecondRecord);
+
+                var endOfBatchForLength = serialized.Position;
+                Assert.AreEqual(batchLength, endOfBatchForLength - startOfBatchForLength);
+
+                if (codec != CompressionCodec.None)
+                {
+                    records.Dispose();
+                }
+            }
+        }
+
+        private ReusableMemoryStream Decompress(ReusableMemoryStream compressed, CompressionCodec codec)
+        {
+            if (codec == CompressionCodec.None)
+            {
+                return compressed;
+            }
+            if (codec == CompressionCodec.Gzip)
+            {
+                var recordsBuffer = new MemoryStream(compressed.GetBuffer(), (int) compressed.Position,
+                    (int) (compressed.Length - compressed.Position)); // disposed by GzipStream
+
+                var decompressed = compressed.Pool.Reserve();
+                using (var zipped = new GZipStream(recordsBuffer, CompressionMode.Decompress))
+                {
+                    using (var tmp = Pool.Reserve())
+                    {
+                        zipped.ReusableCopyTo(decompressed, tmp);
+                    }
+
+                    compressed.Position += recordsBuffer.Position;
+                }
+
+                decompressed.Position = 0;
+                return decompressed;
+            }
+
+            throw new ArgumentException("invalid codec", nameof(codec));
         }
 
         [Test]
@@ -778,10 +990,9 @@ namespace tests_kafka_sharp
             }
         }
 
-        [Test]
-        public void TestDeserializeProduceResponse_V0()
+        private ProduceResponse CreateProducerResponse(ProducePartitionResponse producePartitionResponse)
         {
-            var response = new ProduceResponse
+            return new ProduceResponse
             {
                 ProducePartitionResponse =
                     new CommonResponse<ProducePartitionResponse>
@@ -795,17 +1006,23 @@ namespace tests_kafka_sharp
                                     PartitionsData =
                                         new[]
                                         {
-                                            new ProducePartitionResponse
-                                            {
-                                                ErrorCode = ErrorCode.InvalidMessage,
-                                                Offset = 2312,
-                                                Partition = 34
-                                            }
+                                            producePartitionResponse
                                         }
                                 }
                             }
                     }
             };
+        }
+
+        [Test]
+        public void TestDeserializeProduceResponse_V0()
+        {
+            var response = CreateProducerResponse(new ProducePartitionResponse
+            {
+                ErrorCode = ErrorCode.InvalidMessage,
+                Offset = 2312,
+                Partition = 34
+            });
 
             using (var serialized = new ReusableMemoryStream(null))
             {
@@ -822,28 +1039,13 @@ namespace tests_kafka_sharp
         [Test]
         public void TestDeserializeProduceResponse_v2()
         {
-            var response = new ProduceResponse { ProducePartitionResponse = new CommonResponse<ProducePartitionResponse>
+            var response = CreateProducerResponse(new ProducePartitionResponse
             {
-                TopicsResponse =
-                    new[]
-                    {
-                        new TopicData<ProducePartitionResponse>
-                        {
-                            TopicName = "topic",
-                            PartitionsData =
-                                new[]
-                                {
-                                    new ProducePartitionResponse
-                                    {
-                                        ErrorCode = ErrorCode.InvalidMessage,
-                                        Offset = 2312,
-                                        Partition = 34,
-                                        Timestamp = 42
-                                    }
-                                }
-                        }
-                    }
-            }};
+                ErrorCode = ErrorCode.InvalidMessage,
+                Offset = 2312,
+                Partition = 34,
+                Timestamp = 42
+            });
 
             using (var serialized = new ReusableMemoryStream(null))
             {
@@ -857,6 +1059,34 @@ namespace tests_kafka_sharp
                 Assert.AreEqual(47, p.ThrottleTime);
                 TestCommonResponse(p.ProducePartitionResponse, response.ProducePartitionResponse,
                     (p1, p2) => p1.Partition == p2.Partition && p1.Offset == p2.Offset && p1.ErrorCode == p2.ErrorCode && p1.Timestamp == 42);
+            }
+        }
+
+        [Test]
+        public void TestDeserializeProduceResponse_v5()
+        {
+            var response = CreateProducerResponse(new ProducePartitionResponse
+            {
+                ErrorCode = ErrorCode.InvalidMessage,
+                Offset = 2312,
+                Partition = 34,
+                Timestamp = 42,
+                LogStartOffset = 12,
+            });
+
+            using (var serialized = new ReusableMemoryStream(null))
+            {
+                Basics.WriteArray(serialized, response.ProducePartitionResponse.TopicsResponse, Basics.ApiVersion.V5);
+                BigEndianConverter.Write(serialized, 47);
+                serialized.Position = 0;
+
+                var p = new ProduceResponse();
+                p.Deserialize(serialized, null, Basics.ApiVersion.V5);
+
+                Assert.AreEqual(47, p.ThrottleTime);
+                TestCommonResponse(p.ProducePartitionResponse, response.ProducePartitionResponse,
+                    (p1, p2) => p1.Partition == p2.Partition && p1.Offset == p2.Offset && p1.ErrorCode == p2.ErrorCode
+                        && p1.Timestamp == 42 && p1.LogStartOffset == 12);
             }
         }
 
@@ -990,7 +1220,7 @@ namespace tests_kafka_sharp
                             }
                     }
             };
-            
+
             using (var serialized = new ReusableMemoryStream(null))
             {
                 var config = new SerializationConfig();
@@ -1075,6 +1305,172 @@ namespace tests_kafka_sharp
                     Assert.AreEqual(p1.Partition, p2.Partition);
                     Assert.AreEqual(p1.ErrorCode, p2.ErrorCode);
                     Assert.AreEqual(p1.HighWatermarkOffset, p2.HighWatermarkOffset);
+                    Assert.AreEqual(p1.Messages.Count, p2.Messages.Count);
+                    foreach (var zipped in p1.Messages.Zip(p2.Messages, Tuple.Create))
+                    {
+                        Assert.AreEqual(zipped.Item1.Offset, zipped.Item2.Offset);
+                        CollectionAssert.AreEqual(zipped.Item1.Message.Key as byte[], zipped.Item2.Message.Key as byte[]);
+                        CollectionAssert.AreEqual(zipped.Item1.Message.Value as byte[],
+                            zipped.Item2.Message.Value as byte[]);
+                    }
+
+                    return true;
+                });
+            }
+        }
+
+        [TestCase(CompressionCodec.None)]
+        [TestCase(CompressionCodec.Gzip)]
+        public void TestDeserializeFetchResponse_V4(CompressionCodec compression)
+        {
+            var response = new FetchResponse
+            {
+                ThrottleTime = 47,
+                FetchPartitionResponse =
+                    new CommonResponse<FetchPartitionResponse>
+                    {
+                        TopicsResponse =
+                            new[]
+                            {
+                                new TopicData<FetchPartitionResponse>
+                                {
+                                    TopicName = "Buffy_contre_les_zombies",
+                                    PartitionsData =
+                                        new[]
+                                        {
+                                            new FetchPartitionResponse
+                                            {
+                                                ErrorCode = ErrorCode.NoError,
+                                                HighWatermarkOffset = 714,
+                                                Partition = 999999,
+                                                LastStableOffset = 404,
+                                                AbortedTransactions = new []
+                                                {
+                                                    new AbortedTransaction{FirstOffset = 3, ProducerId = 4}, 
+                                                },
+                                                Messages =
+                                                    new List<ResponseMessage>
+                                                    {
+                                                        new ResponseMessage
+                                                        {
+                                                            Offset = 0,
+                                                            Message = new Message { Key = Key, Value = Value }
+                                                        }
+                                                    },
+                                                Compression = compression
+                                            }
+                                        }
+                                }
+                            }
+                    }
+            };
+
+            using (var serialized = new ReusableMemoryStream(Pool))
+            {
+                var config = new SerializationConfig();
+                BigEndianConverter.Write(serialized, response.ThrottleTime);
+                Basics.WriteArray(serialized, response.FetchPartitionResponse.TopicsResponse, config, Basics.ApiVersion.V4);
+                serialized.Position = 0;
+
+                var f = new FetchResponse();
+                f.Deserialize(serialized, config, Basics.ApiVersion.V4);
+
+                Assert.AreEqual(response.ThrottleTime, f.ThrottleTime);
+                TestCommonResponse(f.FetchPartitionResponse, response.FetchPartitionResponse, (p1, p2) =>
+                {
+                    Assert.AreEqual(p1.Partition, p2.Partition);
+                    Assert.AreEqual(p1.ErrorCode, p2.ErrorCode);
+                    Assert.AreEqual(p1.HighWatermarkOffset, p2.HighWatermarkOffset);
+                    Assert.AreEqual(p1.LastStableOffset, p2.LastStableOffset);
+                    Assert.AreEqual(p1.AbortedTransactions.Length, p2.AbortedTransactions.Length);
+                    foreach (var zipped in p1.AbortedTransactions.Zip(p2.AbortedTransactions, Tuple.Create))
+                    {
+                        Assert.AreEqual(zipped.Item1.ProducerId, zipped.Item2.ProducerId);
+                        Assert.AreEqual(zipped.Item1.FirstOffset, zipped.Item2.FirstOffset);
+                    }
+                    Assert.AreEqual(p1.Messages.Count, p2.Messages.Count);
+                    foreach (var zipped in p1.Messages.Zip(p2.Messages, Tuple.Create))
+                    {
+                        Assert.AreEqual(zipped.Item1.Offset, zipped.Item2.Offset);
+                        CollectionAssert.AreEqual(zipped.Item1.Message.Key as byte[], zipped.Item2.Message.Key as byte[]);
+                        CollectionAssert.AreEqual(zipped.Item1.Message.Value as byte[],
+                            zipped.Item2.Message.Value as byte[]);
+                    }
+
+                    return true;
+                });
+            }
+        }
+
+        [Test]
+        public void TestDeserializeFetchResponse_V5()
+        {
+            var response = new FetchResponse
+            {
+                ThrottleTime = 47,
+                FetchPartitionResponse =
+                    new CommonResponse<FetchPartitionResponse>
+                    {
+                        TopicsResponse =
+                            new[]
+                            {
+                                new TopicData<FetchPartitionResponse>
+                                {
+                                    TopicName = "Buffy_contre_les_zombies",
+                                    PartitionsData =
+                                        new[]
+                                        {
+                                            new FetchPartitionResponse
+                                            {
+                                                ErrorCode = ErrorCode.NoError,
+                                                HighWatermarkOffset = 714,
+                                                Partition = 999999,
+                                                LastStableOffset = 404,
+                                                LogStartOffset = 200,
+                                                AbortedTransactions = new []
+                                                {
+                                                    new AbortedTransaction{FirstOffset = 3, ProducerId = 4},
+                                                },
+                                                Messages =
+                                                    new List<ResponseMessage>
+                                                    {
+                                                        new ResponseMessage
+                                                        {
+                                                            Offset = 0,
+                                                            Message = new Message { Key = Key, Value = Value }
+                                                        }
+                                                    }
+                                            }
+                                        }
+                                }
+                            }
+                    }
+            };
+
+            using (var serialized = new ReusableMemoryStream(null))
+            {
+                var config = new SerializationConfig();
+                BigEndianConverter.Write(serialized, response.ThrottleTime);
+                Basics.WriteArray(serialized, response.FetchPartitionResponse.TopicsResponse, config, Basics.ApiVersion.V5);
+                serialized.Position = 0;
+
+                var f = new FetchResponse();
+                f.Deserialize(serialized, config, Basics.ApiVersion.V5);
+
+                Assert.AreEqual(response.ThrottleTime, f.ThrottleTime);
+                TestCommonResponse(f.FetchPartitionResponse, response.FetchPartitionResponse, (p1, p2) =>
+                {
+                    Assert.AreEqual(p1.Partition, p2.Partition);
+                    Assert.AreEqual(p1.ErrorCode, p2.ErrorCode);
+                    Assert.AreEqual(p1.HighWatermarkOffset, p2.HighWatermarkOffset);
+                    Assert.AreEqual(p1.LastStableOffset, p2.LastStableOffset);
+                    Assert.AreEqual(p1.LogStartOffset, p2.LogStartOffset);
+                    Assert.AreEqual(p1.AbortedTransactions.Length, p2.AbortedTransactions.Length);
+                    foreach (var zipped in p1.AbortedTransactions.Zip(p2.AbortedTransactions, Tuple.Create))
+                    {
+                        Assert.AreEqual(zipped.Item1.ProducerId, zipped.Item2.ProducerId);
+                        Assert.AreEqual(zipped.Item1.FirstOffset, zipped.Item2.FirstOffset);
+                    }
                     Assert.AreEqual(p1.Messages.Count, p2.Messages.Count);
                     foreach (var zipped in p1.Messages.Zip(p2.Messages, Tuple.Create))
                     {
@@ -1875,6 +2271,141 @@ namespace tests_kafka_sharp
 
                 Assert.AreEqual(ErrorCode.NoError, p[0].ErrorCode);
                 Assert.AreEqual(14, p[0].Partition);
+            }
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase(new byte[] {})]
+        [TestCase(new byte[] { 0x00 })]
+        [TestCase(new byte[] { 0xF0, 0x00 })]
+        public void TestSerializeBytesWithVarIntSize(byte[] value)
+        {
+            using (var stream = new ReusableMemoryStream(null))
+            {
+                Basics.SerializeBytesWithVarIntSize(stream, value);
+                stream.Position = 0;
+                Assert.AreEqual(value, Basics.DeserializeBytesWithVarIntSize(stream));
+            }
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("!")]
+        [TestCase("not ascii, aé🤷")]
+        public void TestSerializeStringWithVarIntSize(string value)
+        {
+            using (var stream = new ReusableMemoryStream(null))
+            {
+                Basics.SerializeStringWithVarIntSize(stream, value);
+                stream.Position = 0;
+                Assert.AreEqual(value, Basics.DeserializeStringWithVarIntSize(stream));
+            }
+        }
+
+        [Test]
+        public void TestWriteObjectNull()
+        {
+            using (var stream = new ReusableMemoryStream(null))
+            {
+                Basics.SerializeStringWithVarIntSize(stream, null);
+                stream.Position = 0;
+                Assert.IsNull(Basics.DeserializeBytesWithVarIntSize(stream));
+            }
+        }
+
+        [Test]
+        public void TestWriteObjectSerializable()
+        {
+            var testCases = new object[]
+            {
+                Value, TheValue, new SimpleSerializable(Value), new SimpleSizedSerializable(Value)
+            };
+            ;
+            foreach (object value in testCases)
+            {
+                using (var stream = new ReusableMemoryStream(Pool))
+                {
+                    var serializer = new DummySerializer();
+                    Basics.WriteObject(stream, value, null);
+                    Basics.WriteObject(stream, value, serializer);
+
+                    stream.Position = 0;
+                    CollectionAssert.AreEqual(Value, Basics.DeserializeBytesWithVarIntSize(stream));
+                    CollectionAssert.AreEqual(Value, Basics.DeserializeBytesWithVarIntSize(stream));
+                    Assert.IsFalse(serializer.Called);
+                }
+            }
+        }
+
+        [Test]
+        public void TestWriteObjectNotSerializable()
+        {
+            // A non serializable object will use the serializer
+            using (var stream = new ReusableMemoryStream(Pool))
+            {
+                var serializer = new DummySerializer();
+                Basics.WriteObject(stream, new object(), serializer);
+                stream.Position = 0;
+                CollectionAssert.AreEqual(Value, Basics.DeserializeBytesWithVarIntSize(stream));
+                Assert.IsTrue(serializer.Called);
+            }
+
+            // A non serializable object will not need to allocate extra buffer if serializer
+            // implements ISizableSerializer
+            using (var stream = new ReusableMemoryStream(null))
+            {
+                var serializer = new DummySizableSerializer();
+                Basics.WriteObject(stream, new object(), serializer);
+                stream.Position = 0;
+                CollectionAssert.AreEqual(Value, Basics.DeserializeBytesWithVarIntSize(stream));
+                Assert.IsTrue(serializer.Called);
+            }
+        }
+
+        [Test]
+        [TestCase("")]
+        [TestCase("!")]
+        [TestCase("not ascii, aé🤷")]
+        public void TestSizeofSerializedString(string value)
+        {
+            using (var stream = new ReusableMemoryStream(null))
+            {
+                Basics.SerializeString(stream, value);
+                // size of string is encoded in a short
+                Assert.AreEqual(stream.Length, Basics.SizeOfSerializedString(value) + sizeof(short));
+            }
+        }
+
+
+        [Test]
+        public void TestSizeOfSerializedObject()
+        {
+            Assert.AreEqual(Value.Length, Basics.SizeOfSerializedObject(Value, null));
+            Assert.AreEqual(Basics.SizeOfSerializedString(TheValue), Basics.SizeOfSerializedObject(TheValue, null));
+            Assert.AreEqual(Value.Length, Basics.SizeOfSerializedObject(new SimpleSizedSerializable(Value), null));
+            Assert.AreEqual(Value.Length, Basics.SizeOfSerializedObject(new object(), new DummySizableSerializer()));
+        }
+
+        private class DummySerializer : ISerializer
+        {
+            public bool Called = false;
+
+            public int Serialize(object input, MemoryStream toStream)
+            {
+                Called = true;
+                var initPosition = toStream.Position;
+                toStream.Write(TestSerialization.Value, 0, TestSerialization.Value.Length);
+                return (int)(toStream.Position - initPosition);
+            }
+        }
+
+        private class DummySizableSerializer : DummySerializer, ISizableSerializer
+        {
+            public long SerializedSize(object input)
+            {
+                return Value.Length;
             }
         }
     }

--- a/kafka-sharp/kafka-sharp.UTest/TestVarIntConverter.cs
+++ b/kafka-sharp/kafka-sharp.UTest/TestVarIntConverter.cs
@@ -1,0 +1,247 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+using Kafka.Common;
+using System;
+
+namespace tests_kafka_sharp
+{
+    [TestFixture]
+    internal class TestVarIntConverter
+    {
+        private static readonly IDictionary<long, byte[]> VarIntNumbers = new Dictionary<long, byte[]>
+        {
+            [0L]  = new byte[] { 0x00 },
+            [1L]  = new byte[] { 0x02 },
+            [-1L] = new byte[] { 0x01 },
+            [-64] = new byte[] { 0x7f },
+            [0x7f] = new byte[] {0xfe, 0x01 },
+            [0xff] = new byte[] {0xfe, 0x03 },
+            [short.MinValue] = new byte[] { 0xff, 0xff, 0x03 },
+            [short.MaxValue] = new byte[] { 0xfe, 0xff, 0x03 },
+            [short.MaxValue + 1L] = new byte[] { 0x80, 0x80, 0x04 },
+            [int.MinValue] = new byte[] { 0xff, 0xff, 0xff, 0xff, 0x0f },
+            [int.MaxValue] = new byte[] { 0xfe, 0xff, 0xff, 0xff, 0x0f },
+            [int.MaxValue + 1L] = new byte[] { 0x80, 0x80, 0x80, 0x80, 0x10 },
+            [long.MinValue] = new byte[] { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01 },
+            [long.MaxValue] = new byte[] { 0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01 }
+        };
+
+        [Test]
+        public void TestSizeOfVarInt()
+        {
+            var buffer = new byte[255];
+            var previousPosition = 0L;
+            using (var stream = new MemoryStream(buffer))
+            {
+                foreach (var value in VarIntNumbers.Keys)
+                {
+                    VarIntConverter.Write(stream, value);
+                    Assert.AreEqual(stream.Position - previousPosition, VarIntConverter.SizeOfVarInt(value));
+                    previousPosition = stream.Position;
+                }
+            }
+        }
+
+        [Test]
+        [TestCase(new byte[] { 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80 })]
+        [TestCase(new byte[] { 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02 })]
+        public void TestReadInt64Overflows(byte[] value)
+        {
+            Assert.Throws<OverflowException>(() => VarIntConverter.ReadInt64(new MemoryStream(value)));
+        }
+
+        [Test]
+        public void TestReadInt64()
+        {
+            RunReadIntTestFor(VarIntConverter.ReadInt64, long.MinValue, long.MaxValue);
+        }
+
+        [Test]
+        public void TestReadInt32()
+        {
+            RunReadIntTestFor(VarIntConverter.ReadInt32, int.MinValue, int.MaxValue);
+        }
+
+        [Test]
+        public void TestReadInt16()
+        {
+            RunReadIntTestFor(VarIntConverter.ReadInt16, short.MinValue, short.MaxValue);
+        }
+
+        [Test]
+        public void TestReadByte()
+        {
+            RunReadIntTestFor(VarIntConverter.ReadByte, byte.MinValue, byte.MaxValue, true);
+        }
+
+        [Test]
+        public void TestReadBool()
+        {
+            Assert.IsFalse(VarIntConverter.ReadBool(new MemoryStream(new byte[] { 0x00 })));
+
+            Assert.IsTrue(VarIntConverter.ReadBool(new MemoryStream(new byte[] { 0x01 })));
+            Assert.IsTrue(VarIntConverter.ReadBool(new MemoryStream(new byte[] { 0x02 })));
+            Assert.IsTrue(VarIntConverter.ReadBool(new MemoryStream(new byte[] { 0x80, 0x01 })));
+        }
+
+        private void RunReadIntTestFor<TInteger>(Func<MemoryStream, TInteger> readFunc, TInteger minValue,
+            TInteger maxValue) where TInteger : IComparable =>
+            RunReadIntTestFor(readFunc, minValue, maxValue, true);
+
+        private void RunReadIntTestFor<TInteger>(Func<MemoryStream, TInteger> readFunc, TInteger minValue, TInteger maxValue, bool unsigned)
+            where TInteger: IComparable
+        {
+            foreach (KeyValuePair<long, byte[]> entry in VarIntNumbers)
+            {
+                if (unsigned && entry.Key < 0)
+                {
+                    continue;
+                }
+
+                // If the value is out of the range of the tested type, an OverflowException must be thrown.
+                if (Convert.ToInt64(minValue).CompareTo(entry.Key) <= 0 &&
+                    entry.Key.CompareTo(Convert.ToInt64(maxValue)) <= 0)
+                {
+                    Assert.AreEqual(entry.Key, readFunc(new MemoryStream(entry.Value)));
+                }
+                else
+                {
+                    Assert.Throws<OverflowException>(() => readFunc(new MemoryStream(entry.Value)));
+                }
+            }
+        }
+
+        [Test]
+        public void TestWriteInt64()
+        {
+            foreach (KeyValuePair<long, byte[]> entry in VarIntNumbers)
+            {
+                // 64 bits fit in ceil(64/7) = 10 bytes
+                var actual = new byte[10];
+                VarIntConverter.Write(new MemoryStream(actual), entry.Key);
+                AssertVarIntAreEqual(entry.Value, actual);
+            }
+        }
+
+        [Test]
+        public void TestWriteInt32()
+        {
+            foreach (KeyValuePair<long, byte[]> entry in VarIntNumbers)
+            {
+                if (entry.Key < int.MinValue || entry.Key > int.MaxValue)
+                {
+                    continue;
+                }
+
+                var actual = new byte[5];
+                VarIntConverter.Write(new MemoryStream(actual), (int)entry.Key);
+                AssertVarIntAreEqual(entry.Value, actual);
+            }
+        }
+
+        [Test]
+        public void TestWriteInt16()
+        {
+            foreach (KeyValuePair<long, byte[]> entry in VarIntNumbers)
+            {
+                if (entry.Key < short.MinValue || entry.Key > short.MaxValue)
+                {
+                    continue;
+                }
+
+                var actual = new byte[3];
+                VarIntConverter.Write(new MemoryStream(actual), (short)entry.Key);
+                AssertVarIntAreEqual(entry.Value, actual);
+            }
+        }
+
+        [Test]
+        public void TestWrite()
+        {
+            foreach (KeyValuePair<long, byte[]> entry in VarIntNumbers)
+            {
+                if (entry.Key < byte.MinValue || entry.Key > byte.MaxValue)
+                {
+                    continue;
+                }
+
+                var actual = new byte[2];
+                VarIntConverter.Write(new MemoryStream(actual), (byte)entry.Key);
+                AssertVarIntAreEqual(entry.Value, actual);
+            }
+        }
+
+        [Test]
+        public void TestWriteBool()
+        {
+            var actual = new byte[4];
+            VarIntConverter.Write(new MemoryStream(actual), false);
+            AssertVarIntAreEqual(new byte[] { 0x00 }, actual);
+
+            VarIntConverter.Write(new MemoryStream(actual), true);
+            AssertVarIntAreEqual(new byte[] { 0x02 }, actual); /* zigzag(1) = 0x02 */
+        }
+
+        [Test]
+        public void TestAssertVarIntEqual()
+        {
+            // This test ensures that our assertVarIntEqual is working as expected.
+            AssertVarIntAreEqual(new byte[0], new byte[0]);
+            AssertVarIntAreEqual(new byte[] {0x01}, new byte[] {0x01});
+            AssertVarIntAreEqual(new byte[] { 0x81, 0x01 }, new byte[] { 0x81, 0x01 });
+            AssertVarIntAreEqual(new byte[] { 0x01 }, new byte[] { 0x01, 0x00 });
+            AssertVarIntAreEqual(new byte[] { 0x01, 0xAF }, new byte[] { 0x01 });
+
+            Assert.Throws<AssertionException>(() => AssertVarIntAreEqual(
+                new byte[] {0x01}, new byte[] {0x02}));
+            Assert.Throws<AssertionException>(() => AssertVarIntAreEqual(
+                new byte[] { 0x81, 0x03 }, new byte[] { 0x81, 0x01 }));
+            Assert.Throws<AssertionException>(() => AssertVarIntAreEqual(
+                new byte[] { 0x81, 0x01 }, new byte[] { 0x81, 0x81 }));
+            Assert.Throws<AssertionException>(() => AssertVarIntAreEqual(
+                new byte[0], new byte[] { 0x02 }));
+
+        }
+        /// <summary>
+        /// Compare two VarInt values in the given buffers. The buffers can be larger than the VarInt
+        /// (ie: trailing bytes in both arrays are allowed).
+        ///
+        /// Throws a NUnit.Framework.AssertionException if the values don't match.
+        /// </summary>
+        /// <param name="expected">Expected value</param>
+        /// <param name="actual">Actual value</param>
+        public void AssertVarIntAreEqual(byte[] expected, byte[] actual)
+        {
+            if (expected.Length == 0 && actual.Length == 0)
+            {
+                return;
+            }
+
+            var length = Math.Min(expected.Length, actual.Length);
+            var areEqual = false;
+            var lastByteFound = false;
+            int i;
+
+            for(i = 0; i < length; ++i)
+            {
+                lastByteFound = (expected[i] & 0x80) == 0;
+                areEqual = expected[i] == actual[i];
+
+                if(!areEqual || lastByteFound)
+                {
+                    break;
+                }
+
+            }
+
+            if(!areEqual || !lastByteFound)
+            {
+                throw new AssertionException(
+                    $"VarInt are not equal at byte {i}, " +
+                    $"expected: [{string.Join(", ", expected)}], " +
+                    $"actual: [{string.Join(", ", actual)}]");
+            }
+        }
+    }
+}

--- a/kafka-sharp/kafka-sharp/Cluster/Cluster.cs
+++ b/kafka-sharp/kafka-sharp/Cluster/Cluster.cs
@@ -214,7 +214,7 @@ namespace Kafka.Cluster
             // Node factory
             var clientId = Encoding.UTF8.GetBytes(configuration.ClientId);
             var serializer = new Node.Serialization(configuration.SerializationConfig, configuration.Compatibility, _pools.RequestsBuffersPool, clientId, configuration.RequiredAcks, configuration.RequestTimeoutMs,
-                                                 configuration.CompressionCodec, configuration.FetchMinBytes, configuration.FetchMaxWaitTime);
+                                                 configuration.CompressionCodec, configuration.FetchMinBytes, configuration.FetchMaxWaitTime, configuration.FetchMaxBytes);
             _nodeFactory = nodeFactory ??
                            ((h, p) =>
                             new Node(string.Format("[{0}:{1}]", h, p),
@@ -457,7 +457,7 @@ namespace Kafka.Cluster
         public void Start()
         {
             Logger.LogInformation("Bootstraping with " + _seeds);
-            Logger.LogInformation("Compatibility with " + ((_configuration.Compatibility == Compatibility.V0_10_1) ? "Kafka 0.10+" : "Kafka 0.8.2"));
+            Logger.LogInformation("Compatibility with " + GetPrettyStringOfVersion(_configuration.Compatibility));
             Logger.LogInformation(
                 string.Format("Configuration: {0} - {1} - {2} - max before overflow: {3} - produce batch size: {4} - client timeout: {5} ms",
                 _configuration.OverflowStrategy == OverflowStrategy.Block ? "blocking" : "discard",
@@ -520,6 +520,21 @@ namespace Kafka.Cluster
                 _configuration.RefreshMetadataInterval,
                 _configuration.RefreshMetadataInterval);
             _started = true;
+        }
+
+        private string GetPrettyStringOfVersion(Compatibility version)
+        {
+            switch (version)
+            {
+                case Compatibility.V0_8_2:
+                    return "Kafka 0.8.2";
+                case Compatibility.V0_10_1:
+                    return "Kafka 0.10";
+                case Compatibility.V0_11_0:
+                    return "Kafka 0.11+";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(version), version, null);
+            }
         }
 
         public async Task Stop()

--- a/kafka-sharp/kafka-sharp/Common/Crc32.cs
+++ b/kafka-sharp/kafka-sharp/Common/Crc32.cs
@@ -5,52 +5,115 @@
 
 // The original code has been stripped of all non used parts and adapted to our use.
 
-using System;
+
+using Kafka.Protocol;
 
 namespace Kafka.Common
 {
     /// <summary>
     /// Implements a 32-bit CRC hash algorithm.
     /// </summary>
-    static class Crc32
+    internal class Crc32
     {
         public const uint DefaultPolynomial = 0xedb88320u;
         public const uint DefaultSeed = 0xffffffffu;
 
-        static uint[] _defaultTable;
+        public const uint CastagnoliPolynomial = 0x82F63B78u;
+        public const uint CastagnoliSeed = DefaultSeed;
+
+        public uint Polynomial { get; private set; }
+        public uint Seed { get; private set; }
+
+        private uint[] Table;
+
+        private static readonly Crc32 DefaultCrc32;
+        private static readonly Crc32 CastagnoliCrc32;
+
+        /// <summary>
+        /// Compute the CRC-32 of the byte sequence using IEEE standard polynomial values.
+        /// This is the regular "internet" CRC.
+        /// </summary>
+        /// <param name="stream">byte stream</param>
+        /// <param name="start">start offset of the byte sequence</param>
+        /// <param name="size">size of the byte sequence</param>
+        /// <returns></returns>
+        public static uint Compute(ReusableMemoryStream stream, long start, long size) =>
+            DefaultCrc32.ComputeForStream(stream, start, size);
+
+        /// <summary>
+        /// Compute the CRC-32 of the byte sequence using Castagnoli polynomial values.
+        /// This alternate CRC-32 is often used to compute the CRC as it is often yield
+        /// better chances to detect errors in larger payloads.
+        ///
+        /// In particular, it is used to compute the CRC of a RecordBatch in newer versions
+        /// of the Kafka protocol.
+        /// </summary>
+        /// <param name="stream">byte stream</param>
+        /// <param name="start">start offset of the byte sequence</param>
+        /// <param name="size">size of the byte sequence</param>
+        /// <returns></returns>
+        public static uint ComputeCastagnoli(ReusableMemoryStream stream, long start, long size) =>
+            CastagnoliCrc32.ComputeForStream(stream, start, size);
+
+        private Crc32(uint polynomial, uint seed)
+        {
+            Polynomial = polynomial;
+            Seed = seed;
+            InitializeTable();
+        }
 
         static Crc32()
         {
-            InitializeTable(DefaultPolynomial);
+            DefaultCrc32 = new Crc32(DefaultPolynomial, DefaultSeed);
+            CastagnoliCrc32 = new Crc32(CastagnoliPolynomial, CastagnoliSeed);
         }
 
-        public static uint Compute(ReusableMemoryStream stream, long start, long size)
+        private uint ComputeForStream(ReusableMemoryStream stream, long start, long size)
         {
-            var crc = DefaultSeed;
+            var crc = Seed;
 
             var buffer = stream.GetBuffer();
             for (var i = start; i < start + size; ++i)
-                crc = (crc >> 8) ^ _defaultTable[buffer[i] ^ crc & 0xff];
+                crc = (crc >> 8) ^ Table[buffer[i] ^ crc & 0xff];
 
             return ~crc;
         }
 
-        static void InitializeTable(uint polynomial)
+        private void InitializeTable()
         {
-            var createTable = new uint[256];
+            Table = new uint[256];
             for (var i = 0; i < 256; i++)
             {
                 var entry = (uint)i;
                 for (var j = 0; j < 8; j++)
                     if ((entry & 1) == 1)
-                        entry = (entry >> 1) ^ polynomial;
+                        entry = (entry >> 1) ^ Polynomial;
                     else
                         entry = entry >> 1;
-                createTable[i] = entry;
+                Table[i] = entry;
             }
+        }
 
-            if (polynomial == DefaultPolynomial)
-                _defaultTable = createTable;
+        internal static void CheckCrcCastagnoli(int crc, ReusableMemoryStream stream, long crcStartPos, long crcLength = -1)
+        {
+            CheckCrc(CastagnoliCrc32, crc, stream, crcStartPos, crcLength);
+        }
+
+        internal static void CheckCrc(int crc, ReusableMemoryStream stream, long crcStartPos)
+        {
+            CheckCrc(DefaultCrc32, crc, stream, crcStartPos);
+        }
+
+        private static void CheckCrc(Crc32 crcAlgo, int crc, ReusableMemoryStream stream, long crcStartPos, long crcLength = -1)
+        {
+            var length = crcLength == -1 ? stream.Position - crcStartPos : crcLength;
+            var computedCrc = (int)crcAlgo.ComputeForStream(stream, crcStartPos, length);
+            if (computedCrc != crc)
+            {
+                throw new CrcException(
+                    string.Format("Corrupt message: CRC32 does not match. Calculated {0} but got {1}", computedCrc,
+                        crc));
+            }
         }
     }
 }

--- a/kafka-sharp/kafka-sharp/Common/ReusableMemoryStream.cs
+++ b/kafka-sharp/kafka-sharp/Common/ReusableMemoryStream.cs
@@ -14,7 +14,7 @@ namespace Kafka.Common
     /// we can minimize MemoryStream/buffers creation when (de)serialing requests/responses
     /// and we can minimize the number of buffers passed to the network layers.
     /// </summary>
-    class ReusableMemoryStream : MemoryStream, IMemorySerializable, IDisposable
+    class ReusableMemoryStream : MemoryStream, ISizedMemorySerializable, IDisposable
     {
         private static int _nextId;
         private readonly int _id; // Useful to track leaks while debugging
@@ -60,6 +60,11 @@ namespace Kafka.Common
             byte[] array = this.GetBuffer();
             int length = (int) Length;
             toStream.Write(array, 0, length);
+        }
+
+        public long SerializedSize()
+        {
+            return this.Length;
         }
     }
 

--- a/kafka-sharp/kafka-sharp/Common/VarIntConverter.cs
+++ b/kafka-sharp/kafka-sharp/Common/VarIntConverter.cs
@@ -1,0 +1,145 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+using System;
+using System.IO;
+
+namespace Kafka.Common
+{
+    /// <summary>
+    /// Implement encoding and decoding for VarInt format.
+    /// Values are encoded in ZigZag format (a format which allows  to keep small
+    /// binary values for negative integers).
+    ///
+    /// When reading a VarInt, an OverflowError is thrown if the value doesn't fit
+    /// in the expected return type.
+    ///
+    /// Note: we only deal with signed types, since Kafka is implemented in
+    /// Java, which doesn't have unsigned integers.
+    ///
+    /// See: https://developers.google.com/protocol-buffers/docs/encoding#varints
+    /// </summary>
+    internal static class VarIntConverter
+    {
+        private static ulong ToZigZag(long i)
+        {
+            return unchecked((ulong)((i << 1) ^ (i >> 63)));
+        }
+
+        /// <summary>
+        /// Returns the minimum required size in bytes to store the given value as a VarInt.
+        /// </summary>
+        /// <param name="value">value to be represented as a VarInt</param>
+        /// <returns></returns>
+        public static int SizeOfVarInt(long value)
+        {
+            var asZigZag = ToZigZag(value);
+            int nbBytes = 1;
+            while ((asZigZag & 0xffffffffffffff80L) != 0L)
+            {
+                nbBytes += 1;
+                asZigZag = asZigZag >> 7;
+            }
+
+            return nbBytes;
+        }
+
+        public static void Write(MemoryStream stream, long i)
+        {
+            var asZigZag = ToZigZag(i);
+
+            // value & 1111 1111 ... 1000 0000 will zero the last 7 bytes,
+            // if the result is zero, it means we only have those last 7 bytes
+            // to write.
+            while((asZigZag & 0xffffffffffffff80L) != 0L)
+            {
+                // keep only the 7 most significant bytes:
+                // value = (value & 0111 1111)
+                // and add a 1 in the most significant bit of the byte, meaning
+                // it's not the last byte of the VarInt:
+                // value = (value | 1000 0000)
+                stream.WriteByte((byte)((asZigZag & 0x7f) | 0x80));
+                // Shift the 7 bits we just wrote to the stream and continue:
+                asZigZag = asZigZag >> 7;
+            }
+            stream.WriteByte((byte)asZigZag);
+        }
+
+        public static void Write(MemoryStream stream, int i)
+        {
+            Write(stream, (long)i);
+        }
+
+        public static void Write(MemoryStream stream, short i)
+        {
+            Write(stream, (long)i);
+        }
+
+        public static void Write(MemoryStream stream, byte i)
+        {
+            Write(stream, (long)i);
+        }
+
+        public static void Write(MemoryStream stream, bool i)
+        {
+            Write(stream, i ? 1L : 0L);
+        }
+
+        public static long ReadInt64(MemoryStream stream)
+        {
+            ulong asZigZag = 0L; // Result value
+            int i = 0; // Number of bits written
+            long b; // Byte read
+
+            // Check if the 8th bit of the byte is 1, meaning there will be more to read:
+            // b & 1000 0000
+            while (((b = stream.ReadByte()) & 0x80) != 0) {
+                // Take the 7 bits of the byte we want to add and insert them at the
+                // right location (offset i)
+                asZigZag |= (ulong)(b & 0x7f) << i;
+                i += 7;
+                if (i > 63)
+                    throw new OverflowException();
+            }
+
+            if (i == 63 && b != 0x01)
+            {
+                // We read 63 bits, we can only read one more (the most significant bit, MSB),
+                // or it means that the VarInt can't fit in a long.
+                // If the bit to read was 0, we would not have read it (as it's the MSB), thus, it must be 1.
+                throw new OverflowException();
+            }
+
+            asZigZag |= (ulong)b << i;
+
+            // The value is signed
+            if ((asZigZag & 0x1) == 0x1)
+            {
+                return (-1 * ((long)(asZigZag >> 1) + 1));
+            }
+
+
+            return (long)(asZigZag >> 1);
+        }
+
+        public static int ReadInt32(MemoryStream stream)
+        {
+            return checked((int)ReadInt64(stream));
+        }
+
+        public static short ReadInt16(MemoryStream stream)
+        {
+            return checked((short)ReadInt64(stream));
+        }
+
+        public static byte ReadByte(MemoryStream stream)
+        {
+            return checked((byte)ReadInt64(stream));
+        }
+
+        public static bool ReadBool(MemoryStream stream)
+        {
+            return ReadInt64(stream) != 0;
+        }
+    }
+}

--- a/kafka-sharp/kafka-sharp/Kafka.csproj
+++ b/kafka-sharp/kafka-sharp/Kafka.csproj
@@ -75,12 +75,14 @@
     <Compile Include="Batching\Grouping.cs" />
     <Compile Include="Cluster\Cluster.cs" />
     <Compile Include="Cluster\Node.cs" />
+    <Compile Include="Common\VarIntConverter.cs" />
     <Compile Include="Protocol\KafkaLz4.cs" />
     <Compile Include="Common\Timestamp.cs" />
     <Compile Include="Protocol\ConsumerGroupRequests.cs" />
     <Compile Include="Protocol\ConsumerGroupResponses.cs" />
     <Compile Include="Protocol\GroupCoordinationRequests.cs" />
     <Compile Include="Protocol\GroupCoordinationResponses.cs" />
+    <Compile Include="Protocol\RecordBatch.cs" />
     <Compile Include="Public\Exceptions.cs" />
     <Compile Include="Public\Loggers\ConsoleLogger.cs" />
     <Compile Include="Public\Loggers\DevNullLogger.cs" />

--- a/kafka-sharp/kafka-sharp/Kafka.netstandard.csproj
+++ b/kafka-sharp/kafka-sharp/Kafka.netstandard.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="lz4net" Version="1.0.15.93" />
     <PackageReference Include="Snappy.Standard" Version="0.2.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.0.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/kafka-sharp/kafka-sharp/Protocol/Basics.cs
+++ b/kafka-sharp/kafka-sharp/Protocol/Basics.cs
@@ -3,8 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Runtime.Serialization;
 using Kafka.Common;
 using Kafka.Public;
+#if !NETSTANDARD1_3
+using Snappy;
+#endif
 
 namespace Kafka.Protocol
 {
@@ -18,16 +24,26 @@ namespace Kafka.Protocol
 
     static class Basics
     {
+        // Value representing the case when the size of an object is unknown (when calling a SizeOf*() method).
+        // This is kind of ugly but the alternative is to throw an exception, which is very expensive.
+        public static readonly long UnknownSize = long.MinValue;
+
         public static readonly byte[] MinusOne32 = { 0xff, 0xff, 0xff, 0xff };
-        static readonly byte[] MinusOne16 = { 0xff, 0xff };
+        public static readonly byte[] MinusOne16 = { 0xff, 0xff };
+        public static readonly byte[] MinusOneVarInt = { 0x01 };
         public static readonly byte[] Zero64 = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
         public static readonly byte[] Zero32 = { 0x00, 0x00, 0x00, 0x00 };
+        public static readonly byte[] ZeroVarInt = { 0x00 };
 
         public static readonly byte[][] VersionBytes =
         {
-            new byte[]{ 0x00, 0x00 }, 
-            new byte[]{ 0x00, 0x01 }, 
+            new byte[]{ 0x00, 0x00 },
+            new byte[]{ 0x00, 0x01 },
             new byte[]{ 0x00, 0x02 },
+            new byte[]{ 0x00, 0x03 },
+            new byte[]{ 0x00, 0x04 },
+            new byte[]{ 0x00, 0x05 },
+            new byte[]{ 0x00, 0x06 },
         };
 
         public enum ApiVersion
@@ -36,6 +52,10 @@ namespace Kafka.Protocol
             V0 = 0,
             V1 = 1,
             V2 = 2,
+            V3 = 3,
+            V4 = 4,
+            V5 = 5,
+            V6 = 6,
         }
 
         public enum ApiKey : short
@@ -56,6 +76,12 @@ namespace Kafka.Protocol
             ListGroupsRequest = 16,
             SaslHandshake = 17,
             ApiVersions = 18,
+        }
+
+        public enum IsolationLevel : byte
+        {
+            ReadUncommited = 0,
+            ReadCommited = 1,
         }
 
         public static byte[] DeserializeBytes(ReusableMemoryStream stream)
@@ -79,6 +105,28 @@ namespace Kafka.Protocol
             }
 
             BigEndianConverter.Write(stream, b.Length);
+            stream.Write(b, 0, b.Length);
+        }
+
+        public static byte[] DeserializeBytesWithVarIntSize(ReusableMemoryStream stream)
+        {
+            var len = VarIntConverter.ReadInt32(stream);
+            if (len == -1)
+                return null;
+
+            var buffer = new byte[len];
+            stream.Read(buffer, 0, len);
+            return buffer;
+        }
+        public static void SerializeBytesWithVarIntSize(ReusableMemoryStream stream, byte[] b)
+        {
+            if (b == null)
+            {
+                stream.Write(MinusOneVarInt, 0, MinusOneVarInt.Length);
+                return;
+            }
+
+            VarIntConverter.Write(stream, b.Length);
             stream.Write(b, 0, b.Length);
         }
 
@@ -111,6 +159,28 @@ namespace Kafka.Protocol
             stream.Position = start;
             BigEndianConverter.Write(stream, (short)length);
             stream.Position = current;
+        }
+
+        public static string DeserializeStringWithVarIntSize(ReusableMemoryStream stream)
+        {
+            var len = VarIntConverter.ReadInt32(stream);
+            // per contract, null string is represented with -1 len.
+            if (len == -1)
+                return null;
+
+            return _stringDeser.Deserialize(stream, len) as string;
+        }
+
+        public static void SerializeStringWithVarIntSize(ReusableMemoryStream stream, string s)
+        {
+            if (s == null)
+            {
+                stream.Write(MinusOneVarInt, 0, MinusOneVarInt.Length);
+                return;
+            }
+
+            VarIntConverter.Write(stream, _stringSer.SerializedSize(s));
+            _stringSer.Serialize(s, stream);
         }
 
         public static ReusableMemoryStream WriteMessageLength(ReusableMemoryStream stream)
@@ -282,5 +352,215 @@ namespace Kafka.Protocol
                 return null;
             return deserializer.Deserialize(stream, len);
         }
+
+        /// <summary>
+        /// Write the size of the serialized object as a VarInt then the serialized object on the stream.
+        ///
+        /// </summary>
+        /// <param name="stream">target stream</param>
+        /// <param name="o">object to serialize and write to target</param>
+        /// <param name="serializer">serializer to use if object is not serializable</param>
+        public static void WriteObject(ReusableMemoryStream stream, object o, ISerializer serializer)
+        {
+            if (o is byte[] asBytes)
+            {
+                SerializeBytesWithVarIntSize(stream, asBytes);
+            }
+            else if (o is string asString)
+            {
+                SerializeStringWithVarIntSize(stream, asString);
+            }
+            else
+            {
+                if (o == null)
+                {
+                    stream.Write(MinusOneVarInt, 0, MinusOneVarInt.Length);
+                    return;
+                }
+
+                var expectedPosition = -1L;
+                if (o is ISizedMemorySerializable asSizedSerializable)
+                {
+                    var expectedSize = asSizedSerializable.SerializedSize();
+                    VarIntConverter.Write(stream, expectedSize);
+                    expectedPosition = stream.Position + expectedSize;
+                    asSizedSerializable.Serialize(stream);
+                }
+                else if (serializer is ISizableSerializer sizableSerializer)
+                {
+                    var expectedSize = sizableSerializer.SerializedSize(o);
+                    VarIntConverter.Write(stream, expectedSize);
+                    expectedPosition = stream.Position + expectedSize;
+                    sizableSerializer.Serialize(o, stream);
+                }
+                else
+                {
+                    // If we can not know the size of the serialized object in advance, we need to use an intermediate buffer.
+                    using (var buffer = stream.Pool.Reserve())
+                    {
+                        if (o is IMemorySerializable asSerializable)
+                        {
+                            asSerializable.Serialize(buffer);
+                        }
+                        else
+                        {
+                            serializer.Serialize(o, buffer);
+                        }
+                        WriteObject(stream, buffer, null);
+                    }
+
+                    return;
+                }
+
+                if (expectedPosition != stream.Position)
+                {
+                    throw new SerializationException(
+                        "SerializedSize() returned a different value than the size of the serialized object written");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Return the size of the string in bytes when serialized with <see cref="SerializeString" />.
+        ///
+        /// While the method returns a long, the size of a string is actually bounded by an integer size.
+        /// </summary>
+        /// <param name="s">string to be serialized</param>
+        /// <returns>size in bytes</returns>
+        public static long SizeOfSerializedString(string s)
+        {
+            if (s == null)
+            {
+                return -1;
+            }
+            return _stringSer.SerializedSize(s);
+        }
+
+        /// <summary>
+        /// Returns the size in bytes of the object when serialized with <see cref="WriteObject" />.
+        /// </summary>
+        /// <param name="o">object to be serialized</param>
+        /// <param name="serializer">optional serializer used if th object is not serializable</param>
+        /// <returns></returns>
+        public static long SizeOfSerializedObject(object o, ISizableSerializer serializer)
+        {
+            if (o == null)
+            {
+                return -1;
+            }
+
+            if (o is byte[] asBytes)
+            {
+                return asBytes.Length;
+            }
+
+            if (o is string asString)
+            {
+                return SizeOfSerializedString(asString);
+            }
+
+            if (o is ISizedMemorySerializable asSizedSerializable)
+            {
+                return asSizedSerializable.SerializedSize();
+            }
+
+            return serializer?.SerializedSize(o) ?? UnknownSize;
+        }
+
+        #region Compression utility
+
+        /// <summary>
+        /// Compress a given stream using a given compression codec
+        /// </summary>
+        /// <param name="uncompressedStream"> The initial stream we want to compress</param>
+        /// <param name="compressedStream"> The stream that want to put the compressed data in (should be empty before calling the method).</param>
+        /// <param name="compression"> The compression we want to use.</param>
+        /// <returns></returns>
+        internal static void CompressStream(ReusableMemoryStream uncompressedStream,
+            ReusableMemoryStream compressedStream, CompressionCodec compression)
+        {
+            if (compression == CompressionCodec.None)
+            {
+                throw new ArgumentException("Compress a stream only when you want compression.");
+            }
+
+            switch (compression)
+            {
+                case CompressionCodec.Gzip:
+                    using (var gzip = new GZipStream(compressedStream, CompressionMode.Compress, true))
+                    {
+                        uncompressedStream.WriteTo(gzip);
+                    }
+
+                    break;
+
+                case CompressionCodec.Lz4:
+                    KafkaLz4.Compress(compressedStream, uncompressedStream.GetBuffer(),
+                        (int) uncompressedStream.Length);
+                    break;
+
+                case CompressionCodec.Snappy:
+#if NETSTANDARD1_3
+                                throw new NotImplementedException();
+#else
+                    compressedStream.SetLength(SnappyCodec.GetMaxCompressedLength((int) uncompressedStream.Length));
+                {
+                    int size = SnappyCodec.Compress(uncompressedStream.GetBuffer(), 0, (int) uncompressedStream.Length,
+                        compressedStream.GetBuffer(), 0);
+                    compressedStream.SetLength(size);
+                }
+#endif
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Uncompress a byte array into a stream.
+        /// </summary>
+        /// <param name="uncompressed">The stream that will contain the uncompressed data (must be given empty).</param>
+        /// <param name="body">The byte array that we want to uncompress.</param>
+        /// <param name="offset">The index in the body where the data we want to uncompress starts.</param>
+        /// <param name="length">The length of the data in the body that we want to uncompress.</param>
+        /// <param name="codec">The compression codec that was used to compress the data in the body.</param>
+        internal static void Uncompress(ReusableMemoryStream uncompressed, byte[] body, int offset, int length, CompressionCodec codec)
+        {
+            try
+            {
+                if (codec == CompressionCodec.Snappy)
+                {
+#if NETSTANDARD1_3
+                    throw new NotImplementedException();
+#else
+                    uncompressed.SetLength(SnappyCodec.GetUncompressedLength(body, offset, length));
+                    SnappyCodec.Uncompress(body, offset, length, uncompressed.GetBuffer(), 0);
+#endif
+                }
+                else if (codec == CompressionCodec.Gzip)
+                {
+                    using (var compressed = new MemoryStream(body, offset, length, false))
+                    {
+                        using (var zipped = new GZipStream(compressed, CompressionMode.Decompress))
+                        {
+                            using (var tmp = uncompressed.Pool.Reserve())
+                            {
+                                zipped.ReusableCopyTo(uncompressed, tmp);
+                            }
+                        }
+                    }
+                }
+                else // compression == CompressionCodec.Lz4
+                {
+                    KafkaLz4.Uncompress(uncompressed, body, offset);
+                }
+
+                uncompressed.Position = 0;
+            }
+            catch (Exception ex)
+            {
+                throw new UncompressException("Invalid compressed data.", codec, ex);
+            }
+        }
+
+        #endregion
     }
 }

--- a/kafka-sharp/kafka-sharp/Protocol/Basics.cs
+++ b/kafka-sharp/kafka-sharp/Protocol/Basics.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
-using System.Runtime.Serialization;
 using Kafka.Common;
 using Kafka.Public;
 #if !NETSTANDARD1_3
@@ -414,7 +413,7 @@ namespace Kafka.Protocol
 
                 if (expectedPosition != stream.Position)
                 {
-                    throw new SerializationException(
+                    throw new Exception(
                         "SerializedSize() returned a different value than the size of the serialized object written");
                 }
             }

--- a/kafka-sharp/kafka-sharp/Protocol/Message.cs
+++ b/kafka-sharp/kafka-sharp/Protocol/Message.cs
@@ -10,7 +10,8 @@ namespace Kafka.Protocol
     internal enum MessageVersion
     {
         V0 = 0,
-        V1 = 1
+        V1 = 1,
+        // Message V2 is implemented in RecordBatch and shall not be used here.
     }
 
     internal struct Message

--- a/kafka-sharp/kafka-sharp/Protocol/Message.cs
+++ b/kafka-sharp/kafka-sharp/Protocol/Message.cs
@@ -2,6 +2,7 @@
 // You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 using System;
+using System.Collections.Generic;
 using Kafka.Common;
 using Kafka.Public;
 
@@ -18,6 +19,7 @@ namespace Kafka.Protocol
     {
         public object Key;
         public object Value;
+        public ICollection<KafkaRecordHeader> Headers;
         public long TimeStamp;
 
         // Visible for tests

--- a/kafka-sharp/kafka-sharp/Protocol/ProduceRequest.cs
+++ b/kafka-sharp/kafka-sharp/Protocol/ProduceRequest.cs
@@ -3,13 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO.Compression;
+using System.Linq;
 using Kafka.Common;
 using Kafka.Public;
-using LZ4;
-#if !NET_CORE
-using Snappy;
-#endif
+
 namespace Kafka.Protocol
 {
     using Serializers = Tuple<ISerializer, ISerializer>;
@@ -19,6 +16,7 @@ namespace Kafka.Protocol
         public IEnumerable<TopicData<PartitionData>> TopicsData;
         public int Timeout;
         public short RequiredAcks;
+        public string TransactionalID;
 
         #region Serialization
 
@@ -29,6 +27,10 @@ namespace Kafka.Protocol
 
         public void SerializeBody(ReusableMemoryStream stream, object extra, Basics.ApiVersion version)
         {
+            if (version >= Basics.ApiVersion.V3)
+            {
+                Basics.SerializeString(stream, TransactionalID);
+            }
             BigEndianConverter.Write(stream, RequiredAcks);
             BigEndianConverter.Write(stream, Timeout);
             Basics.WriteArray(stream, TopicsData, extra, version);
@@ -55,12 +57,69 @@ namespace Kafka.Protocol
         public void Serialize(ReusableMemoryStream stream, object extra, Basics.ApiVersion version)
         {
             BigEndianConverter.Write(stream, Partition);
+
+            if (version >= Basics.ApiVersion.V3)
+            {
+                ISerializer keySerializer = null, valueSerializer = null;
+                if (extra is Serializers asSerializers)
+                {
+                    keySerializer = asSerializers.Item1;
+                    valueSerializer = asSerializers.Item2;
+                }
+
+                SerializeRecordBatch(stream, keySerializer, valueSerializer);
+            }
+            else
+            {
+                SerializeMessageSet(stream, extra as Serializers, version >= Basics.ApiVersion.V2 ? MessageVersion.V1 : MessageVersion.V0);
+            }
+        }
+
+        private void SerializeRecordBatch(ReusableMemoryStream stream, ISerializer keySerializer,
+            ISerializer valueSerializer)
+        {
+            // Starting Produce request V3, messages are encoded in the new RecordBatch.
+            var batch = new RecordBatch
+            {
+                CompressionCodec = CompressionCodec,
+                Records = Messages.Select(message => new Record
+                {
+                    Key = EnsureSizedSerializable(message.Key, keySerializer),
+                    Value = EnsureSizedSerializable(message.Value, valueSerializer),
+                    Timestamp = message.TimeStamp,
+                    // If the serializer is not compatible, we already resolved this
+                    // previously, so it's ok if the cast returns null
+                    KeySerializer = keySerializer as ISizableSerializer,
+                    ValueSerializer = valueSerializer as ISizableSerializer
+                }),
+
+            };
+
+            Basics.WriteSizeInBytes(stream, batch.Serialize);
+        }
+
+        private static object EnsureSizedSerializable(object o, ISerializer serializer)
+        {
+            if (Basics.SizeOfSerializedObject(o, serializer as ISizableSerializer) == Basics.UnknownSize)
+            {
+                using (ReusableMemoryStream buffer = new ReusableMemoryStream(null))
+                {
+                    serializer.Serialize(o, buffer);
+                    return buffer.GetBuffer();
+                }
+            }
+
+            return o;
+        }
+
+        private void SerializeMessageSet(ReusableMemoryStream stream, Serializers serializers, MessageVersion version)
+        {
             Basics.WriteSizeInBytes(stream, Messages,
                 new SerializationInfo
                 {
-                    Serializers = extra as Serializers,
+                    Serializers = serializers,
                     CompressionCodec = CompressionCodec,
-                    MessageVersion = version >= Basics.ApiVersion.V2 ? MessageVersion.V1 : MessageVersion.V0
+                    MessageVersion = version
                 }, SerializeMessages);
         }
 
@@ -72,7 +131,7 @@ namespace Kafka.Protocol
             {
                 // We always set offsets starting from 0 and increasing by one for each consecutive message.
                 // This is because in compressed messages, when message format is V1, the brokers
-                // will follow this format on disk. You're expected to do the same if you want to 
+                // will follow this format on disk. You're expected to do the same if you want to
                 // avoid offset reassignment and message recompression.
                 // When message format is V0, brokers will rewrite the offsets anyway
                 // so we use the same scheme in all cases.
@@ -106,35 +165,7 @@ namespace Kafka.Protocol
 
                     using (var compressed = stream.Pool.Reserve())
                     {
-                        switch (info.CompressionCodec)
-                        {
-                            case CompressionCodec.Gzip:
-                                using (var gzip = new GZipStream(compressed, CompressionMode.Compress, true))
-                                {
-                                    msgsetStream.WriteTo(gzip);
-                                }
-                                break;
-
-                            case CompressionCodec.Lz4:
-                                KafkaLz4.Compress(compressed, msgsetStream.GetBuffer(), (int) msgsetStream.Length);
-                                break;
-
-                            case CompressionCodec.Snappy:
-                            {
-#if NET_CORE
-                            throw new NotImplementedException();
-#else
-                                compressed.SetLength(SnappyCodec.GetMaxCompressedLength((int) msgsetStream.Length));
-                                {
-                                    int size = SnappyCodec.Compress(msgsetStream.GetBuffer(), 0,
-                                        (int) msgsetStream.Length,
-                                        compressed.GetBuffer(), 0);
-                                    compressed.SetLength(size);
-                                }
-#endif
-                            }
-                                break;
-                        }
+                        Basics.CompressStream(msgsetStream, compressed, info.CompressionCodec);
 
                         var m = new Message
                         {

--- a/kafka-sharp/kafka-sharp/Protocol/ProduceRequest.cs
+++ b/kafka-sharp/kafka-sharp/Protocol/ProduceRequest.cs
@@ -86,6 +86,7 @@ namespace Kafka.Protocol
                 {
                     Key = EnsureSizedSerializable(message.Key, keySerializer),
                     Value = EnsureSizedSerializable(message.Value, valueSerializer),
+                    Headers = message.Headers,
                     Timestamp = message.TimeStamp,
                     // If the serializer is not compatible, we already resolved this
                     // previously, so it's ok if the cast returns null

--- a/kafka-sharp/kafka-sharp/Protocol/ProduceResponse.cs
+++ b/kafka-sharp/kafka-sharp/Protocol/ProduceResponse.cs
@@ -35,6 +35,7 @@ namespace Kafka.Protocol
         public ErrorCode ErrorCode;
         public long Offset;
         public long Timestamp;
+        public long LogStartOffset;
 
         // Used only in tests
         public void Serialize(ReusableMemoryStream stream, object _, Basics.ApiVersion version)
@@ -46,6 +47,10 @@ namespace Kafka.Protocol
             {
                 BigEndianConverter.Write(stream, Timestamp);
             }
+            if (version >= Basics.ApiVersion.V5)
+            {
+                BigEndianConverter.Write(stream, LogStartOffset);
+            }
         }
 
         public void Deserialize(ReusableMemoryStream stream, object _, Basics.ApiVersion version)
@@ -56,6 +61,10 @@ namespace Kafka.Protocol
             if (version >= Basics.ApiVersion.V2)
             {
                 Timestamp = BigEndianConverter.ReadInt64(stream);
+            }
+            if (version >= Basics.ApiVersion.V5)
+            {
+                LogStartOffset = BigEndianConverter.ReadInt64(stream);
             }
         }
     }

--- a/kafka-sharp/kafka-sharp/Protocol/ProtocolException.cs
+++ b/kafka-sharp/kafka-sharp/Protocol/ProtocolException.cs
@@ -42,8 +42,8 @@ namespace Kafka.Protocol
     // Wrong message version
     class UnsupportedMagicByteVersion : ProtocolException
     {
-        public UnsupportedMagicByteVersion(byte badMagic)
-            : base(string.Format("Unsupported magic byte version: {0}, only 0 is supported", badMagic))
+        public UnsupportedMagicByteVersion(byte badMagic, string supported)
+            : base($"Unsupported magic byte version: {badMagic}, only {supported} is supported")
         {
         }
     }

--- a/kafka-sharp/kafka-sharp/Protocol/RecordBatch.cs
+++ b/kafka-sharp/kafka-sharp/Protocol/RecordBatch.cs
@@ -1,0 +1,432 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+using System;
+using System.Collections.Generic;
+using Kafka.Common;
+using Kafka.Public;
+using Deserializers = System.Tuple<Kafka.Public.IDeserializer, Kafka.Public.IDeserializer>;
+
+
+namespace Kafka.Protocol
+{
+    internal enum TimestampType
+    {
+        // This should never happen, as it used to convert V0 message sets into RecordBatch
+        // and thus, there's no timestamp known.
+        LogAppendTime = 1,
+        // Means that the timestamp is set when the record is created.
+        CreateTime = 2,
+    }
+
+    internal class RecordBatch
+    {
+        private static readonly short CompressionCodecMask = 0x07;
+        private static readonly short TransactionalFlagMask = 0x10;
+        private static readonly short ControlFlagMask = 0x20;
+        private static readonly short TimestampTypeMask = 0x08;
+
+        public static readonly long NoProducerId = -1L;
+        public static readonly short NoProducerEpoch = -1;
+        // Represents the BaseSequence value when we don't use the feature of idempotent writes.
+        public static readonly int NoSequence = -1;
+        // Represents the PartitionLeaderEpoch when it's unknown, which is the case when a client produces messages
+        public static readonly int NoPartitionLeaderEpoch = -1;
+
+        // Provided by a ProducerIdRequest, can be set to a default value.
+        public long ProducerId = NoProducerId;
+        public short ProducerEpoch = NoProducerEpoch;
+
+        // Currently, a ProduceRequest can only hold a single RecordBatch, the BaseOffset is thus 0.?
+        public long BaseOffset = 0;
+        public int BaseSequence = NoSequence;
+        public int PartitionLeaderEpoch = NoPartitionLeaderEpoch;
+        public bool IsControl = false;
+        public bool IsTransactional = false;
+
+        public CompressionCodec CompressionCodec;
+        public TimestampType TimestampType;
+
+        public IEnumerable<Record> Records;
+
+        private const int BytesNecessaryToGetLength = 8 // baseOffset
+            + 4; // batchLength
+
+        public void Serialize(ReusableMemoryStream target)
+        {
+            uint crc = 0;
+            int batchLength = -1, lastOffsetDelta = -1;
+            long firstTimestamp = -1L, maxTimestamp = -1L;
+
+            BigEndianConverter.Write(target, BaseOffset);
+            var batchLengthPosition = target.Position;
+            BigEndianConverter.Write(target, batchLength); // placeholder for batchLength: int32
+            // The value of batchLength is the number of bytes required to read after the
+            // batchLength field, we retain the current buffer position to compute it later.
+            var afterBatchLengthPosition = target.Position;
+            BigEndianConverter.Write(target, PartitionLeaderEpoch);
+
+            // Current magic value is 2
+            target.WriteByte(2);
+
+            var crcPosition = target.Position;
+            BigEndianConverter.Write(target, (int)crc); // placeholder for CRC: int32
+            var afterCrcPosition = target.Position;
+
+            short attributes = 0x0;
+            if (CompressionCodec != CompressionCodec.None)
+                attributes |= (short)((short)CompressionCodec & CompressionCodecMask);
+            if (IsTransactional)
+                attributes |= TransactionalFlagMask;
+            if (IsControl)
+                attributes |= ControlFlagMask;
+            if (TimestampType == TimestampType.LogAppendTime)
+                attributes |= TimestampTypeMask;
+
+            BigEndianConverter.Write(target, attributes);
+
+            var lastOffsetDeltaPosition = target.Position;
+            BigEndianConverter.Write(target, lastOffsetDelta); // placeholder for LastOffsetDelta: int32
+
+            var firstTimestampPosition = target.Position;
+            BigEndianConverter.Write(target, firstTimestamp); // placeholder for FirstTimestamp: int64
+
+            var maxTimestampPosition = target.Position;
+            BigEndianConverter.Write(target, maxTimestamp); // placeholder for MaxTimestamp: int64
+
+            BigEndianConverter.Write(target, ProducerId);
+            BigEndianConverter.Write(target, ProducerEpoch);
+            BigEndianConverter.Write(target, BaseSequence); // BaseSequence: int32
+
+            var recordsCountPosition = target.Position;
+            BigEndianConverter.Write(target, lastOffsetDelta);  // RecordsCount: int32
+
+            (lastOffsetDelta, firstTimestamp, maxTimestamp) = CompressionCodec == CompressionCodec.None
+                ? SerializeRecords(target)
+                : SerializeRecordsWithCompression(target, CompressionCodec);
+
+
+            var endPosition = target.Position;
+
+            batchLength = (int)(target.Position - afterBatchLengthPosition);
+            target.Position = batchLengthPosition;
+            BigEndianConverter.Write(target, batchLength);
+
+            target.Position = lastOffsetDeltaPosition;
+            BigEndianConverter.Write(target, lastOffsetDelta);
+
+            target.Position = firstTimestampPosition;
+            BigEndianConverter.Write(target, firstTimestamp);
+
+            target.Position = maxTimestampPosition;
+            BigEndianConverter.Write(target, maxTimestamp);
+
+            target.Position = recordsCountPosition;
+            BigEndianConverter.Write(target, lastOffsetDelta + 1); // actual records count
+
+            // Crc is computed on the object from right after the CRC to the end of the buffer
+            crc = Crc32.ComputeCastagnoli(target, afterCrcPosition, endPosition - afterCrcPosition);
+            target.Position = crcPosition;
+            BigEndianConverter.Write(target, (int)crc);
+
+            target.Position = endPosition;
+        }
+
+        private (int, long, long) SerializeRecords(ReusableMemoryStream target)
+        {
+            int lastOffsetDelta = -1;
+            long firstTimestamp = -1L, maxTimestamp = -1L;
+            foreach (var record in Records)
+            {
+                ++lastOffsetDelta;
+
+                if (firstTimestamp == -1L)
+                {
+                    firstTimestamp = record.Timestamp;
+                }
+
+                if (record.Timestamp > maxTimestamp)
+                {
+                    maxTimestamp = record.Timestamp;
+                }
+
+                record.Serialize(target, firstTimestamp, lastOffsetDelta);
+            }
+
+            return (lastOffsetDelta, firstTimestamp, maxTimestamp);
+        }
+
+        private (int, long, long) SerializeRecordsWithCompression(ReusableMemoryStream target,
+            CompressionCodec compression)
+        {
+            using (var uncompressedStream = target.Pool.Reserve())
+            {
+                var resultOffsetAndTimestamps = SerializeRecords(uncompressedStream);
+                using (var compressed = target.Pool.Reserve())
+                {
+                    Basics.CompressStream(uncompressedStream, compressed, compression);
+                    using (var tmpBuffer = target.Pool.Reserve())
+                    {
+                        compressed.Position = 0;
+                        compressed.ReusableCopyTo(target, tmpBuffer);
+                    }
+
+                    return resultOffsetAndTimestamps;
+                }
+            }
+        }
+
+        // Remark: it might be the case that brokers are authorized to send us partial record batch.
+        // So if the protocol exceptions in this method are triggered, you might want to investigate and remove
+        // them altogether.
+        public void Deserialize(ReusableMemoryStream input, Deserializers deserializers, long endOfAllBatches)
+        {
+            if (input.Position + BytesNecessaryToGetLength > endOfAllBatches)
+            {
+                throw new ProtocolException(
+                    $"Trying to read a batch record at {input.Position} and the end of all batches is {endOfAllBatches}."
+                    + $" There is not enough bytes remaining to even read the first fields...");
+            }
+            BaseOffset = BigEndianConverter.ReadInt64(input);
+            var batchLength = BigEndianConverter.ReadInt32(input);
+            var endOfBatch = input.Position + batchLength;
+            if (endOfAllBatches < endOfBatch)
+            {
+                throw new ProtocolException(
+                    $"The record batch says it has length that stops at {endOfBatch} but the list of all batches stop at {endOfAllBatches}.");
+            }
+            PartitionLeaderEpoch = BigEndianConverter.ReadInt32(input);
+            var magic = input.ReadByte();
+            // Current magic value is 2
+            if ((uint) magic != 2)
+            {
+                throw new UnsupportedMagicByteVersion((byte) magic, "2");
+            }
+
+            var crc = (uint) BigEndianConverter.ReadInt32(input);
+            var afterCrcPosition = input.Position; // The crc is calculated starting from this position
+            Crc32.CheckCrcCastagnoli((int)crc, input, afterCrcPosition, endOfBatch - afterCrcPosition);
+
+            var attributes = BigEndianConverter.ReadInt16(input);
+
+            CompressionCodec = (CompressionCodec) (attributes & CompressionCodecMask);
+            IsTransactional = (attributes & TransactionalFlagMask) != 0;
+            IsControl = (attributes & ControlFlagMask) != 0;
+            TimestampType = (attributes & TimestampTypeMask) > 0
+                ? TimestampType.LogAppendTime
+                : TimestampType.CreateTime;
+
+            var lastOffsetDelta = BigEndianConverter.ReadInt32(input);
+
+            var firstTimestamp = BigEndianConverter.ReadInt64(input);
+            var maxTimestamp = BigEndianConverter.ReadInt64(input);
+
+            ProducerId = BigEndianConverter.ReadInt64(input);
+            ProducerEpoch = BigEndianConverter.ReadInt16(input);
+            BaseSequence = BigEndianConverter.ReadInt32(input);
+
+            var numberOfRecords = BigEndianConverter.ReadInt32(input);
+            Records = DeserializeRecords(input, numberOfRecords, endOfBatch, firstTimestamp, deserializers);
+        }
+
+        public IEnumerable<Record> DeserializeRecords(ReusableMemoryStream input, int numberOfRecords, long endOfBatch,
+            long firstTimeStamp, Deserializers deserializers)
+        {
+            if (CompressionCodec == CompressionCodec.None)
+            {
+                return DeserializeRecordsUncompressed(input, numberOfRecords, endOfBatch, firstTimeStamp,
+                    deserializers);
+            }
+            using (var uncompressedStream = input.Pool.Reserve())
+            {
+                Basics.Uncompress(uncompressedStream, input.GetBuffer(), (int) input.Position,
+                    (int) (endOfBatch - input.Position), CompressionCodec);
+                input.Position = endOfBatch;
+                return new List<Record>(DeserializeRecordsUncompressed(uncompressedStream, numberOfRecords, endOfBatch, firstTimeStamp,
+                    deserializers)); // We use a list here to force iteration to take place, so that we can release uncompressedStream
+            }
+        }
+
+        public IEnumerable<Record> DeserializeRecordsUncompressed(ReusableMemoryStream input, int numberOfRecords, long endOfBatch,
+            long firstTimeStamp, Deserializers deserializers)
+        {
+            for (var i = 0; i < numberOfRecords; i++)
+            {
+                var length = VarIntConverter.ReadInt32(input);
+                if (input.Length - input.Position < length)
+                {
+                    throw new ProtocolException(
+                        $"Record said it was of length {length}, but actually only {input.Length - input.Position} bytes remain");
+                }
+
+                var attributes = input.ReadByte(); // ignored for now
+                var timeStampDelta = VarIntConverter.ReadInt64(input);
+                var offsetDelta = VarIntConverter.ReadInt32(input);
+
+                var keyLength = VarIntConverter.ReadInt32(input);
+                var key = keyLength == -1 ? null : deserializers.Item1.Deserialize(input, keyLength);
+                var valueLength = VarIntConverter.ReadInt32(input);
+                var value = valueLength == -1 ? null : deserializers.Item1.Deserialize(input, valueLength);
+
+                var headersCount = VarIntConverter.ReadInt32(input);
+                var headers = new List<RecordHeader>();
+                for (var j = 0; j < headersCount; j++)
+                {
+                    var header = new RecordHeader();
+                    header.Deserialize(input);
+                    headers.Add(header);
+                }
+
+                yield return new Record
+                {
+                    Headers = headers,
+                    Key = key,
+                    Timestamp = firstTimeStamp + timeStampDelta,
+                    Value = value,
+                    Offset = BaseOffset + offsetDelta
+                };
+            }
+        }
+    }
+
+    internal struct Record
+    {
+        public object Key;
+        public object Value;
+
+        public ISizableSerializer KeySerializer;
+        public ISizableSerializer ValueSerializer;
+
+        public long Timestamp;
+
+        public long Offset;
+
+        public ICollection<RecordHeader> Headers;
+
+        public ReusableMemoryStream Serialize(ReusableMemoryStream target, long baseTimestamp, long offsetDelta)
+        {
+            var timestampDelta = Timestamp - baseTimestamp;
+            VarIntConverter.Write(target, SizeOfBodyInBytes(offsetDelta, timestampDelta));
+
+            // Record attributes are always null.
+            target.WriteByte(0x00);
+
+            VarIntConverter.Write(target, timestampDelta);
+            VarIntConverter.Write(target, offsetDelta);
+
+            Basics.WriteObject(target, Key, KeySerializer);
+            Basics.WriteObject(target, Value, ValueSerializer);
+
+            if (Headers == null)
+            {
+                target.Write(Basics.ZeroVarInt, 0, Basics.ZeroVarInt.Length);
+            }
+            else
+            {
+                VarIntConverter.Write(target, Headers.Count);
+                foreach (RecordHeader header in Headers)
+                {
+                    header.Serialize(target);
+                }
+            }
+
+            return target;
+        }
+
+        /// <summary>
+        /// Returns the size of the Serialized object without the attributes.
+        /// </summary>
+        /// <returns>Serialized size of the body in bytes</returns>
+        public long SizeOfBodyInBytes(long offsetDelta, long timestampDelta)
+        {
+            var size = 1L; // always 1 byte for attributes
+
+            size += VarIntConverter.SizeOfVarInt(offsetDelta);
+            size += VarIntConverter.SizeOfVarInt(timestampDelta);
+
+            if (Key == null)
+            {
+                size += Basics.MinusOneVarInt.Length;
+            }
+            else
+            {
+                var keySize = Basics.SizeOfSerializedObject(Key, KeySerializer);
+                size += keySize + VarIntConverter.SizeOfVarInt(keySize);
+            }
+
+            if (Value == null)
+            {
+                size += Basics.MinusOneVarInt.Length;
+            }
+            else
+            {
+                var valueSize = Basics.SizeOfSerializedObject(Value, ValueSerializer);
+                size += valueSize + VarIntConverter.SizeOfVarInt(valueSize);
+            }
+
+            if (Headers == null)
+            {
+                size += Basics.ZeroVarInt.Length;
+            }
+            else
+            {
+                var headersCount = 0;
+                foreach (RecordHeader header in Headers)
+                {
+                    size += (int)header.SerializedSize();
+                    ++headersCount;
+                }
+
+                size += VarIntConverter.SizeOfVarInt(headersCount);
+            }
+
+            return size;
+        }
+    }
+
+    internal struct RecordHeader
+    {
+        public string Key;
+        public object Value;
+
+        public ISizableSerializer ValueSerializer;
+
+        public ReusableMemoryStream Serialize(ReusableMemoryStream target)
+        {
+            CheckValues();
+
+            Basics.SerializeStringWithVarIntSize(target, Key);
+            Basics.WriteObject(target, Value, ValueSerializer);
+
+            return target;
+        }
+
+        public void Deserialize(ReusableMemoryStream stream)
+        {
+            Key = Basics.DeserializeStringWithVarIntSize(stream);
+            Value = Basics.DeserializeBytesWithVarIntSize(stream);
+        }
+
+        public long SerializedSize()
+        {
+            CheckValues();
+
+            var keySize = Basics.SizeOfSerializedString(Key);
+            var valueSize = Basics.SizeOfSerializedObject(Value, ValueSerializer);
+            return keySize + valueSize + VarIntConverter.SizeOfVarInt(keySize)  + VarIntConverter.SizeOfVarInt(valueSize);
+        }
+
+        private void CheckValues()
+        {
+            if (Key == null)
+            {
+                throw new ArgumentNullException("Key");
+            }
+
+            if (Value == null)
+            {
+                throw new ArgumentNullException("Value");
+            }
+        }
+    }
+}

--- a/kafka-sharp/kafka-sharp/Public/Configuration.cs
+++ b/kafka-sharp/kafka-sharp/Public/Configuration.cs
@@ -51,7 +51,15 @@ namespace Kafka.Public
         /// Use latest versions of all API, as supported by Kafka 0.10.1. This means that producer
         /// will use v1 message format, and consumer will be able to read v0 and v1 message format.
         /// </summary>
-        V0_10_1
+        V0_10_1,
+
+        /// <summary>
+        /// Use latest versions of some API, as supported by Kafka 0..0. This means that producer
+        /// will use v2 message format, and consumer will be able to read v0, v1 and v2 message format.
+        /// For now, only api key Produce (0) and Fetch (1) are updated, mostly to take advantage of
+        /// the new message format.
+        /// </summary>
+        V0_11_0
     }
 
     /// <summary>
@@ -303,6 +311,13 @@ namespace Kafka.Public
         /// data to accumulate before answering the request.
         /// </summary>
         public int FetchMinBytes = 1;
+
+        /// <summary>
+        /// The maximum amount of data brokers should return for a fetch request.
+        /// If the first message to be sent takes more size than this limit, then the
+        /// broker will still send it (alone) so that the consumer is not blocked.
+        /// </summary>
+        public int FetchMaxBytes = 50 * 1024 * 1024;
 
         /// <summary>
         /// The number of bytes of messages to attempt to fetch for each topic-partition

--- a/kafka-sharp/kafka-sharp/Public/KafkaRecord.cs
+++ b/kafka-sharp/kafka-sharp/Public/KafkaRecord.cs
@@ -123,4 +123,39 @@ namespace Kafka.Public
         /// </summary>
         public DateTime Timestamp { get; internal set; }
     }
+
+    /// <summary>
+    /// Header in a record, as got from consuming a topic.
+    /// An header is only available for records encoded using the "Message format" V3
+    /// or more (starting kafka 0.11).
+    /// </summary>
+    public struct KafkaRecordHeader
+    {
+        /// <summary>
+        /// Key of the header.
+        /// </summary>
+        public string Key { get; set; }
+
+        /// <summary>
+        /// Raw value of the header.
+        /// </summary>
+        public byte[] Value { get; set; }
+
+        /// <summary>
+        /// Throws an exception if the values of the objects are invalid.
+        /// In particular, both the key and value must not be null.
+        /// </summary>
+        public void Validate()
+        {
+            if (Key == null)
+            {
+                throw new ArgumentNullException(nameof(Key));
+            }
+
+            if (Value == null)
+            {
+                throw new ArgumentNullException(nameof(Value));
+            }
+        }
+    }
 }


### PR DESCRIPTION
Implement essential of version 0.11 of Kafka protocole.

What we call the essential are: Produce API Key V3 Fetch   API Key V4 RecordBatch  (which would be messageSet V2 but is not...)

Most fields that we added are just blank in the API requests, the only new behaviour supported with this version is the ability to use RecordBatch both for producing messages and for consuming them.

