### PR TITLE
Use latest System.Reactive (and .NET Standard 2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # "High Performance" .NET Kafka Driver
 
+This is a fork that upgrades the project to target .NET Standard 2.0 and `System.Reactive` v4.
+
+[The link to the merge request to the original project](https://github.com/criteo/kafka-sharp/pull/54)
+
+[The link to the NuGet package of this fork](https://www.nuget.org/packages/TheMulti0.kafka-sharp/)
+
 A .NET implementation of the Apache Kafka client side protocol geared toward performance (both
 throughput and memory wise). It is especially suited for scenarios where applications
 are streaming a large number of messages across a fair number of topics.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # "High Performance" .NET Kafka Driver
 
-This is a fork that upgrades the project to target .NET Standard 2.0 and `System.Reactive` v4.
-
-[The link to the merge request to the original project](https://github.com/criteo/kafka-sharp/pull/54)
-
-[The link to the NuGet package of this fork](https://www.nuget.org/packages/TheMulti0.kafka-sharp/)
-
 A .NET implementation of the Apache Kafka client side protocol geared toward performance (both
 throughput and memory wise). It is especially suited for scenarios where applications
 are streaming a large number of messages across a fair number of topics.

--- a/kafka-sharp/kafka-sharp.UTest/kafka.UTest.netstandard.csproj
+++ b/kafka-sharp/kafka-sharp.UTest/kafka.UTest.netstandard.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>kafka-sharp.UTest</AssemblyName>
     <PackageId>kafka-sharp.UTest</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -25,9 +25,7 @@
     <PackageReference Include="NUnit" Version="3.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
     <PackageReference Include="Moq" Version="4.7.10" />
-    <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
-    <PackageReference Include="System.Reactive.Interfaces" Version="3.1.1" />
-    <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
+    <PackageReference Include="System.Reactive" Version="4.4.1" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>

--- a/kafka-sharp/kafka-sharp/Kafka.netstandard.csproj
+++ b/kafka-sharp/kafka-sharp/Kafka.netstandard.csproj
@@ -24,9 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
-    <PackageReference Include="System.Reactive.Interfaces" Version="3.1.1" />
-    <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
+    <PackageReference Include="System.Reactive" Version="4.4.1" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.7.0" />
     <PackageReference Include="lz4net" Version="1.0.15.93" />
     <PackageReference Include="Snappy.Standard" Version="0.2.0" />

--- a/kafka-sharp/kafka-sharp/Kafka.netstandard.csproj
+++ b/kafka-sharp/kafka-sharp/Kafka.netstandard.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>kafka-sharp</AssemblyName>
     <AssemblyDescription>High Performance .NET Kafka Client</AssemblyDescription>
     <PackageId>kafka-sharp</PackageId>
@@ -22,10 +22,6 @@
     <Owners>Criteo</Owners>
     <Description>High Performance .NET Kafka Client</Description>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="../../LICENSE" Pack="true" PackagePath=""/>
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Reactive.Core" Version="3.1.1" />

--- a/kafka-sharp/kafka-sharp/Kafka.netstandard.csproj
+++ b/kafka-sharp/kafka-sharp/Kafka.netstandard.csproj
@@ -24,6 +24,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="../../LICENSE" Pack="true" PackagePath=""/>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="System.Reactive" Version="4.4.1" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.7.0" />
     <PackageReference Include="lz4net" Version="1.0.15.93" />

--- a/kafka-sharp/sample-kafka-sharp/sample-kafka-sharp.netstandard.csproj
+++ b/kafka-sharp/sample-kafka-sharp/sample-kafka-sharp.netstandard.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>sample-kafka-sharp</AssemblyName>
     <PackageId>sample-kafka-sharp</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -21,9 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
-    <PackageReference Include="System.Reactive.Interfaces" Version="3.1.1" />
-    <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
+    <PackageReference Include="System.Reactive" Version="4.4.1" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Hello,

I have noticed that referencing Kafka-Sharp in a brand new .NET Core 2.0/3.0 app with the latest `System.Reactive` v4.4.1 layer and `kafka-sharp` installed, I would run into a classic transitive dependency issue.

When trying to reference types from the reactive library, the compiler will not be able to match the correct one for me, since I reference the latest `System.Reactive` package, and `kafka-sharp` brings along the older v3 `System.Reactive` layers.

Therefore, I upgraded the `kafka-sharp.netstandard` project to reference the latest `System.Reactive` library.

The upgrade required targeting `.netstandard2.0` rather than `.netstandard1.6`, and the tests and sample projects to `.netcoreapp2.0` rather than `.netcoreapp1.1`.

[Anyway, I have uploaded this fork to NuGet.](https://www.nuget.org/packages/TheMulti0.kafka-sharp/1.0.0)

Have a good day!
Multi
